### PR TITLE
Add block form for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ IdentityIdpFunctions::DemoFunction.handle(
 )
 ```
 
+Expected local development workflow is with a block:
+
+```ruby
+IdentityIdpFunctions::ProofAddress.handle(event: event, context: context) do |result|
+  store(result[:address_result])
+end
+```
+
 ## Adding a new Lambda
 
 - Lambdas should have an entry point at `source/$function_name/lib/$function_name.rb`

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,3 +1,3 @@
 module IdentityIdpFunctions
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/source/proof_address/spec/proof_address_spec.rb
+++ b/source/proof_address/spec/proof_address_spec.rb
@@ -66,6 +66,29 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
     it 'runs' do
       IdentityIdpFunctions::ProofAddress.handle(event: { 'body' => body.to_json }, context: nil)
     end
+
+    context 'when called with a block' do
+      it 'gives the results to the block instead of posting to the callback URL' do
+        yielded_result = nil
+        IdentityIdpFunctions::ProofAddress.handle(
+          event: { 'body' => body.to_json },
+          context: nil
+        ) do |result|
+          yielded_result = result
+        end
+
+        expect(yielded_result).to eq(
+          address_result: {
+            exception: nil,
+            errors: {},
+            messages: [],
+            success: true,
+          }
+        )
+
+        expect(a_request(:post, callback_url)).to_not have_been_made
+      end
+    end
   end
 
   describe '#proof' do


### PR DESCRIPTION
This should make it easier to share code with development mode and in specs, when we can't necessarily POST to a webhook URL