### PR TITLE
Switch to explicit/lazy requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ As a gem:
 gem 'identity-idp-functions', github: '18f/identity-idp-functions'
 ```
 
-Calling a handler directly
+**The functions depend on various Github gem dependencies so they are lazily loaded**
+
+Calling a handler directly:
 
 ```ruby
-require 'identity-idp-functions'
+require 'identity-idp-functions/demo_function'
 
 IdentityIdpFunctions::DemoFunction.handle(
   event: event,
@@ -23,6 +25,8 @@ IdentityIdpFunctions::DemoFunction.handle(
 Expected local development workflow is with a block:
 
 ```ruby
+require 'identity-idp-functions/proof_address'
+
 IdentityIdpFunctions::ProofAddress.handle(event: event, context: context) do |result|
   store(result[:address_result])
 end
@@ -32,6 +36,7 @@ end
 
 - Lambdas should have an entry point at `source/$function_name/lib/$function_name.rb`
 - Update `source/template.yaml` to add the required metadata about the lambda. Copy `DemoFunction` and replace all the various cases of its name (`demo_function`, `Demo Function`, `DemoFunction`)
+- Add a file in `lib/identity-idp-functions/$function_name.rb` so that it can be loaded as `require "identity-idp-functions/$function_name"`
 
 ## Running tests
 

--- a/lib/identity-idp-functions.rb
+++ b/lib/identity-idp-functions.rb
@@ -3,12 +3,13 @@ require 'identity-idp-functions/version'
 # This is the entry point for this repository as a gem, ex
 # require 'identity-idp-functions'
 
-# Load each lambda, they should have a file at "source/$function_name/lib/$function_name.rb"
-root = File.expand_path(File.join(__dir__, '..'))
-Dir[File.join(root, 'source', '*', 'lib')].each do |lambda_lib_dir|
-  lambda_name = File.basename(lambda_lib_dir.gsub(%r|lib/?$|, ''))
-  require File.expand_path(File.join(lambda_lib_dir, "#{lambda_name}.rb"))
-end
-
 module IdentityIdpFunctions
+  module_function
+
+  # Helper for building a ruby require path for
+  # "source/$function_name/lib/$function_name.rb"
+  def function_path(function_name)
+    root = File.expand_path(File.join(__dir__, '..'))
+    File.expand_path(File.join(root, 'source', function_name, 'lib', "#{function_name}.rb"))
+  end
 end

--- a/lib/identity-idp-functions/demo_function.rb
+++ b/lib/identity-idp-functions/demo_function.rb
@@ -1,0 +1,4 @@
+require 'identity-idp-functions'
+
+# This is a trampoline to allow lazily loading the demo_function function
+require IdentityIdpFunctions.function_path('demo_function')

--- a/lib/identity-idp-functions/proof_address.rb
+++ b/lib/identity-idp-functions/proof_address.rb
@@ -1,0 +1,4 @@
+require 'identity-idp-functions'
+
+# This is a trampoline to allow lazily loading the proof_address function
+require IdentityIdpFunctions.function_path('proof_address')

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,3 +1,3 @@
 module IdentityIdpFunctions
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/source/demo_function/spec/demo_function_spec.rb
+++ b/source/demo_function/spec/demo_function_spec.rb
@@ -1,3 +1,5 @@
+require 'identity-idp-functions/demo_function'
+
 RSpec.describe IdentityIdpFunctions::DemoFunction do
   before do
     stub_const(

--- a/source/proof_address/spec/proof_address_spec.rb
+++ b/source/proof_address/spec/proof_address_spec.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'identity-idp-functions/proof_address'
 
 RSpec.describe IdentityIdpFunctions::ProofAddress do
   let(:idp_api_auth_token) { SecureRandom.hex }

--- a/spec/identity-idp-functions_spec.rb
+++ b/spec/identity-idp-functions_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe IdentityIdpFunctions do
   end
 
   it "loads the handlers functions" do
+    require 'identity-idp-functions/demo_function'
     expect(defined? IdentityIdpFunctions::DemoFunction).to be_truthy
   end
 end


### PR DESCRIPTION
**Why**: The IDP doesn't load some of the gem dependencies in the test
environment, so eagerly loading those functions results in an error

I ran into errors in test in https://github.com/18F/identity-idp/pull/4264, so hopefully merging this will allow me to fix those