### PR TITLE
Fix typo and remove duplicate function from list

### DIFF
--- a/source/template.yaml
+++ b/source/template.yaml
@@ -267,8 +267,7 @@ Resources:
         - ','
         - - !GetAtt DemoFunctionFunction.Arn
           - !GetAtt ProofAddressFunction.Arn
-          - !GetAtt ProofAddressFunction.Arn
-          - !GetAtt ProofAddressMockFuncion.Arn
+          - !GetAtt ProofAddressMockFunction.Arn
           - !GetAtt ProofResolutionFunction.Arn
           - !GetAtt ProofResolutionMockFunction.Arn
 


### PR DESCRIPTION
Deployment pipeline is failing for Lambda functions.  Typo in function list.