### PR TITLE
Remove eager ENV.fetch

### DIFF
--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,3 +1,3 @@
 module IdentityIdpFunctions
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -7,18 +7,14 @@ module IdentityIdpFunctions
   class ProofAddress
     def self.handle(event:, context:, &callback_block)
       params = JSON.parse(event['body'], symbolize_names: true)
-      new(
-        idp_api_auth_token: ENV.fetch("IDP_API_AUTH_TOKEN"),
-        **params,
-      ).proof(&callback_block)
+      new(**params).proof(&callback_block)
     end
 
-    attr_reader :applicant_pii, :callback_url, :idp_api_auth_token
+    attr_reader :applicant_pii, :callback_url
 
-    def initialize(applicant_pii:, callback_url:, idp_api_auth_token:)
+    def initialize(applicant_pii:, callback_url:)
       @applicant_pii = applicant_pii
       @callback_url = callback_url
-      @idp_api_auth_token = idp_api_auth_token
     end
 
     def proof(&callback_block)
@@ -48,7 +44,7 @@ module IdentityIdpFunctions
         Faraday.post(
           callback_url,
           callback_body.to_json,
-          "X-API-AUTH-TOKEN" => idp_api_auth_token,
+          "X-API-AUTH-TOKEN" => ENV.fetch("IDP_API_AUTH_TOKEN"),
           "Content-Type" => 'application/json',
           "Accept" => 'application/json'
         )

--- a/source/proof_address/spec/proof_address_spec.rb
+++ b/source/proof_address/spec/proof_address_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
       IdentityIdpFunctions::ProofAddress.new(
         callback_url: callback_url,
         applicant_pii: applicant_pii,
-        idp_api_auth_token: idp_api_auth_token,
       )
     end
 
@@ -116,6 +115,11 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
 
       stub_request(:post, callback_url).
         with(headers: { 'X-API-AUTH-TOKEN' => idp_api_auth_token })
+
+      stub_const(
+        'ENV',
+        'IDP_API_AUTH_TOKEN' => idp_api_auth_token,
+      )
     end
 
     context 'with a successful response from the proofer' do

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -7,18 +7,14 @@ module IdentityIdpFunctions
   class ProofAddressMock
     def self.handle(event:, context:, &callback_block)
       params = JSON.parse(event['body'], symbolize_names: true)
-      new(
-        idp_api_auth_token: ENV['IDP_API_AUTH_TOKEN'],
-        **params,
-      ).proof(&callback_block)
+      new(**params).proof(&callback_block)
     end
 
-    attr_reader :applicant_pii, :callback_url, :idp_api_auth_token
+    attr_reader :applicant_pii, :callback_url
 
-    def initialize(applicant_pii:, callback_url:, idp_api_auth_token:)
+    def initialize(applicant_pii:, callback_url:)
       @applicant_pii = applicant_pii
       @callback_url = callback_url
-      @idp_api_auth_token = idp_api_auth_token
     end
 
     def proof(&callback_block)
@@ -50,7 +46,7 @@ module IdentityIdpFunctions
         Faraday.post(
           callback_url,
           callback_body.to_json,
-          "X-API-AUTH-TOKEN" => idp_api_auth_token,
+          "X-API-AUTH-TOKEN" => ENV.fetch('IDP_API_AUTH_TOKEN'),
           "Content-Type" => 'application/json',
           "Accept" => 'application/json'
         )

--- a/source/proof_address_mock/spec/proof_address_mock_spec.rb
+++ b/source/proof_address_mock/spec/proof_address_mock_spec.rb
@@ -88,13 +88,17 @@ RSpec.describe IdentityIdpFunctions::ProofAddressMock do
       IdentityIdpFunctions::ProofAddressMock.new(
         callback_url: callback_url,
         applicant_pii: applicant_pii,
-        idp_api_auth_token: idp_api_auth_token,
       )
     end
 
     before do
       stub_request(:post, callback_url).
         with(headers: { 'X-API-AUTH-TOKEN' => idp_api_auth_token })
+
+      stub_const(
+        'ENV',
+        'IDP_API_AUTH_TOKEN' => idp_api_auth_token,
+      )
     end
 
     context 'with a successful response from the proofer' do

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -9,19 +9,15 @@ module IdentityIdpFunctions
   class ProofResolution
     def self.handle(event:, context:, &callback_block)
       params = JSON.parse(event['body'], symbolize_names: true)
-      new(
-        idp_api_auth_token: ENV.fetch('IDP_API_AUTH_TOKEN'),
-        **params,
-      ).proof(&callback_block)
+      new(**params).proof(&callback_block)
     end
 
-    attr_reader :applicant_pii, :callback_url, :should_proof_state_id, :idp_api_auth_token
+    attr_reader :applicant_pii, :callback_url, :should_proof_state_id
 
-    def initialize(applicant_pii:, callback_url:, should_proof_state_id:, idp_api_auth_token:)
+    def initialize(applicant_pii:, callback_url:, should_proof_state_id:)
       @applicant_pii = applicant_pii
       @callback_url = callback_url
-      @should_proof_state_id =should_proof_state_id
-      @idp_api_auth_token = idp_api_auth_token
+      @should_proof_state_id = should_proof_state_id
     end
 
     def proof(&callback_block)
@@ -74,7 +70,7 @@ module IdentityIdpFunctions
         Faraday.post(
           callback_url,
           callback_body.to_json,
-          "X-API-AUTH-TOKEN" => idp_api_auth_token,
+          "X-API-AUTH-TOKEN" => ENV.fetch('IDP_API_AUTH_TOKEN'),
           "Content-Type" => 'application/json',
           "Accept" => 'application/json'
         )

--- a/source/proof_resolution/spec/proof_resolution_spec.rb
+++ b/source/proof_resolution/spec/proof_resolution_spec.rb
@@ -128,7 +128,6 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
         callback_url: callback_url,
         applicant_pii: applicant_pii,
         should_proof_state_id: should_proof_state_id,
-        idp_api_auth_token: idp_api_auth_token,
       )
     end
 
@@ -138,6 +137,11 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
 
       stub_request(:post, callback_url).
         with(headers: { 'X-API-AUTH-TOKEN' => idp_api_auth_token })
+
+      stub_const(
+        'ENV',
+        'IDP_API_AUTH_TOKEN' => idp_api_auth_token,
+      )
     end
 
     context 'with a successful response from the proofer' do

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -8,19 +8,15 @@ module IdentityIdpFunctions
   class ProofResolutionMock
     def self.handle(event:, context:, &callback_block)
       params = JSON.parse(event['body'], symbolize_names: true)
-      new(
-        idp_api_auth_token: ENV['IDP_API_AUTH_TOKEN'],
-        **params,
-      ).proof(&callback_block)
+      new(**params).proof(&callback_block)
     end
 
-    attr_reader :applicant_pii, :callback_url, :should_proof_state_id, :idp_api_auth_token
+    attr_reader :applicant_pii, :callback_url, :should_proof_state_id
 
-    def initialize(applicant_pii:, callback_url:, should_proof_state_id:, idp_api_auth_token:)
+    def initialize(applicant_pii:, callback_url:, should_proof_state_id:)
       @applicant_pii = applicant_pii
       @callback_url = callback_url
-      @should_proof_state_id =should_proof_state_id
-      @idp_api_auth_token = idp_api_auth_token
+      @should_proof_state_id = should_proof_state_id
     end
 
     def proof(&callback_block)
@@ -74,7 +70,7 @@ module IdentityIdpFunctions
         Faraday.post(
           callback_url,
           callback_body.to_json,
-          "X-API-AUTH-TOKEN" => idp_api_auth_token,
+          "X-API-AUTH-TOKEN" => ENV.fetch('IDP_API_AUTH_TOKEN'),
           "Content-Type" => 'application/json',
           "Accept" => 'application/json'
         )

--- a/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
+++ b/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
@@ -100,13 +100,17 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
         callback_url: callback_url,
         applicant_pii: applicant_pii,
         should_proof_state_id: should_proof_state_id,
-        idp_api_auth_token: idp_api_auth_token,
       )
     end
 
     before do
       stub_request(:post, callback_url).
         with(headers: { 'X-API-AUTH-TOKEN' => idp_api_auth_token })
+
+      stub_const(
+        'ENV',
+        'IDP_API_AUTH_TOKEN' => idp_api_auth_token,
+      )
     end
 
     context 'with a successful response from the proofer' do


### PR DESCRIPTION
**Why**: It gets triggered in "local" mode when we call
this inline from the IDP, but at that point the env variable
will not be there

Also updates mock functions to fetch because they need the
parameter as well