### PR TITLE
Update CircleCI to run RSpec first before uploading lambdas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ workflows:
 jobs:
   build-specs:
     executor: ubuntu-2004
+    steps:
       - checkout
       - run-specs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,19 +8,25 @@ executors:
 workflows:
   lambda-functions:
     jobs:
-      - build:
+      - build-specs
+      - build-deploy:
+          requires: build-specs
           context: login-sandbox
 
 jobs:
-  build:
+  build-specs:
+    executor: ubuntu-2004
+      - checkout
+      - run-specs
+
+  build-deploy:
     executor: ubuntu-2004
     steps:
       - brew-install
       - aws-cli-configure
       - sam-cli-install
       - checkout
-      - build-repo
-      - run-specs
+      - build-repo-s3-upload
 
 commands:
   sam-cli-install:
@@ -65,7 +71,7 @@ commands:
             aws configure set default.aws_secret_access_key $AWS_SECRET_ACCESS_KEY
             aws configure set default.region $AWS_DEFAULT_REGION
 
-  build-repo:
+  build-repo-s3-upload:
     steps:
       - run:
           name: "Validate SAM template"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ workflows:
     jobs:
       - build-specs
       - build-deploy:
-          requires: build-specs
+          requires:
+            - build-specs
           context: login-sandbox
 
 jobs:


### PR DESCRIPTION
I noticed that the step to upload to S3 happened before we ran the local RSpec tests, so I tried flipping that around

Also, do we want to add a filter to the upload step to S3 uploads only happen from the `master` branch?