### PR TITLE
Don't fail deploy pipeline if empty changeset

### DIFF
--- a/source/buildspec.yml
+++ b/source/buildspec.yml
@@ -17,7 +17,8 @@ phases:
           --stack-name $STACK_NAME \
           --parameter-overrides gitsha=$GITSHA \
           environment=$ENVIRONMENT \
-          --capabilities CAPABILITY_IAM
+          --capabilities CAPABILITY_IAM \
+          --no-fail-on-empty-changeset
   post_build:
     commands:
       - APPLICATION_FUNCTIONS=$(aws ssm get-parameter --name /$ENVIRONMENT/idp/lambda/application-functions --query 'Parameter.Value' --output text)


### PR DESCRIPTION
Don't fail the deployment pipeline if the sam deploy returns an empty changeset.  May need to rerun pipeline and don't want the pipeline to show failed state.