### PR TITLE
Updates to SAM template and CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,19 @@ workflows:
       - build-deploy:
           requires:
             - build-specs
-          context: login-sandbox
+          context: 
+            - login-sandbox
+            - login-prod
+      - build-deploy-copy:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - build-specs
+          context:
+            - login-sandbox
+            - login-prod
 
 jobs:
   build-specs:
@@ -28,7 +40,19 @@ jobs:
       - aws-cli-configure
       - sam-cli-install
       - checkout
-      - build-repo-s3-upload
+      - build-repo
+
+  build-deploy-copy:
+    executor: ubuntu-2004
+    steps:
+      - brew-install
+      - aws-cli-configure
+      - aws-cli-configure-prod
+      - sam-cli-install
+      - checkout
+      - build-repo
+      - copy-to-s3
+      - copy-to-s3-prod
 
 commands:
   sam-cli-install:
@@ -72,8 +96,17 @@ commands:
             aws configure set default.aws_access_key_id $AWS_ACCESS_KEY_ID
             aws configure set default.aws_secret_access_key $AWS_SECRET_ACCESS_KEY
             aws configure set default.region $AWS_DEFAULT_REGION
+            
+  aws-cli-configure-prod:
+    steps:
+      - run:
+          name: "Configure AWS CLI Prod"
+          command: | 
+            aws configure set profile.prod.aws_access_key_id $prod_AWS_ACCESS_KEY_ID
+            aws configure set profile.prod.aws_secret_access_key $prod_AWS_SECRET_ACCESS_KEY
+            aws configure set profile.prod.region $AWS_DEFAULT_REGION
 
-  build-repo-s3-upload:
+  build-repo:
     steps:
       - run:
           name: "Validate SAM template"
@@ -108,8 +141,24 @@ commands:
             zip identity-idp-functions.zip identity-idp-functions.template.yaml
             zip identity-idp-functions.zip buildspec.yml
             zip identity-idp-functions.zip gitsha.txt
+  
+  copy-to-s3:
+    steps:
+      - run:
+          name: "Copy packages to S3"
+          command: |
+            cd source
             aws s3 cp identity-idp-functions.template.yaml s3://$DEPLOY_S3_BUCKET/circleci/identity-idp-functions/$CIRCLE_BRANCH/
             aws s3 cp identity-idp-functions.zip s3://$DEPLOY_S3_BUCKET/circleci/identity-idp-functions/$CIRCLE_BRANCH/
+
+  copy-to-s3-prod:
+    steps:
+      - run:
+          name: "Copy packages to S3 prod"
+          command: |
+            cd source
+            aws s3 cp identity-infra-functions.template.yaml s3://$prod_DEPLOY_S3_BUCKET/circleci/identity-infra-functions/$CIRCLE_BRANCH/ --profile prod
+            aws s3 cp identity-infra-functions.zip s3://$prod_DEPLOY_S3_BUCKET/circleci/identity-infra-functions/$CIRCLE_BRANCH/ --profile prod
 
   run-specs:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,17 @@ workflows:
   lambda-functions:
     jobs:
       - build-specs
-      - build-deploy:
+      - build-package:
+          filters:
+            branches:
+              ignore:
+                - master
           requires:
             - build-specs
           context: 
             - login-sandbox
             - login-prod
-      - build-deploy-copy:
+      - build-package-copy:
           filters:
             branches:
               only:
@@ -33,7 +37,7 @@ jobs:
       - checkout
       - run-specs
 
-  build-deploy:
+  build-package:
     executor: ubuntu-2004
     steps:
       - brew-install
@@ -42,7 +46,7 @@ jobs:
       - checkout
       - build-repo
 
-  build-deploy-copy:
+  build-package-copy:
     executor: ubuntu-2004
     steps:
       - brew-install

--- a/source/template.yaml
+++ b/source/template.yaml
@@ -57,6 +57,9 @@ Resources:
   DemoFunctionFunction:
     Type: AWS::Serverless::Function
     Properties:
+      FunctionName: !Sub
+        - ${Environment}-idp-functions-DemoFunctionFunction
+        - Environment: !Ref environment
       CodeUri: demo_function/lib/
       Handler: demo_function.IdentityIdpFunctions::DemoFunction.handle
       AutoPublishAlias: !Ref environment
@@ -157,6 +160,9 @@ Resources:
   ProofAddressFunction:
     Type: AWS::Serverless::Function 
     Properties:
+      FunctionName: !Sub
+        - ${Environment}-idp-functions-ProofAddressFunction
+        - Environment: !Ref environment
       CodeUri: proof_address/lib/
       Handler: proof_address.IdentityIdpFunctions::ProofAddress.handle
       AutoPublishAlias: !Ref environment
@@ -280,6 +286,9 @@ Resources:
   ProofAddressMockFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
+      FunctionName: !Sub
+        - ${Environment}-idp-functions-ProofAddressMockFunction
+        - Environment: !Ref environment
       CodeUri: proof_address_mock/lib/
       Handler: proof_address_mock.IdentityIdpFunctions::ProofAddressMock.handle
       MemorySize: 128
@@ -380,6 +389,9 @@ Resources:
   ProofResolutionFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
+      FunctionName: !Sub
+        - ${Environment}-idp-functions-ProofResolutionFunction
+        - Environment: !Ref environment
       CodeUri: proof_resolution/lib/
       Handler: proof_resolution.IdentityIdpFunctions::ProofResolution.handle
       MemorySize: 128
@@ -480,6 +492,9 @@ Resources:
   ProofResolutionMockFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
+      FunctionName: !Sub
+        - ${Environment}-idp-functions-ProofResolutionMockFunction
+        - Environment: !Ref environment
       CodeUri: proof_resolution_mock/lib/
       Handler: proof_resolution_mock.IdentityIdpFunctions::ProofResolutionMock.handle
       MemorySize: 128


### PR DESCRIPTION
Update CircleCi to only copy to S3 when building the master branch Issue https://github.com/18F/identity-devops/issues/2973
Copy template to prod lambda s3 bucket 
Set function names instead of using SAM template default name

