### PR TITLE
Update requires

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "aws-sdk", '~> 3'
+gem 'aws-sdk-ssm', '~> 1.55'
+gem 'aws-sdk-s3', '~> 1.73'
 
 gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'aws-sdk-ssm', '~> 1.55'
-gem 'aws-sdk-s3', '~> 1.73'
-
 gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.4.1'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.7.0'

--- a/identity-idp-functions.gemspec
+++ b/identity-idp-functions.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "retries", ">= 0.0.5"
+  spec.add_dependency 'aws-sdk-ssm', '>= 1.55'
+  spec.add_dependency 'aws-sdk-s3', '>= 1.73'
 
   spec.add_development_dependency "rake", "~> 13"
 end

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,3 +1,3 @@
 module IdentityIdpFunctions
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/source/aws-ruby-sdk/Gemfile
+++ b/source/aws-ruby-sdk/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
-gem "aws-sdk", '~> 3'
 gem "logger"

--- a/source/demo_function/lib/Gemfile
+++ b/source/demo_function/lib/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 ruby '~> 2.7.0'
+
+gem 'aws-sdk-s3', '~> 1.73'

--- a/source/proof_address/lib/Gemfile
+++ b/source/proof_address/lib/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby '~> 2.7.0'
 
+gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.4.1'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.7.0'

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -4,7 +4,7 @@ require 'json'
 require 'retries'
 require 'proofer'
 require 'lexisnexis'
-require_relative 'ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
+require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
 
 module IdentityIdpFunctions
   class ProofAddress

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -1,7 +1,9 @@
+require 'bundler/setup' if !defined?(Bundler)
+require 'faraday'
+require 'json'
+require 'retries'
 require 'proofer'
 require 'lexisnexis'
-require 'faraday'
-require 'retries'
 require_relative 'ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
 
 module IdentityIdpFunctions

--- a/source/proof_address_mock/lib/Gemfile
+++ b/source/proof_address_mock/lib/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby '~> 2.7.0'
 
+gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.7.0'
 gem 'retries'

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -1,5 +1,7 @@
-require 'proofer'
+require 'bundler/setup' if !defined?(Bundler)
 require 'faraday'
+require 'json'
+require 'proofer'
 require 'retries'
 require_relative 'address_mock_client'
 require_relative 'ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -4,7 +4,7 @@ require 'json'
 require 'proofer'
 require 'retries'
 require_relative 'address_mock_client'
-require_relative 'ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
+require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
 
 module IdentityIdpFunctions
   class ProofAddressMock

--- a/source/proof_resolution/lib/Gemfile
+++ b/source/proof_resolution/lib/Gemfile
@@ -2,8 +2,9 @@ source "https://rubygems.org"
 
 ruby '~> 2.7.0'
 
-gem 'faraday'
+gem 'aws-sdk-ssm', '~> 1.55'
 gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
+gem 'faraday'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.4.1'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.7.0'
 gem 'retries'

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -1,7 +1,8 @@
-require 'json'
-require 'proofer'
+require 'bundler/setup' if !defined?(Bundler)
 require 'faraday'
+require 'json'
 require 'retries'
+require 'proofer'
 require 'aamva'
 require 'lexisnexis'
 require_relative 'ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -5,7 +5,7 @@ require 'retries'
 require 'proofer'
 require 'aamva'
 require 'lexisnexis'
-require_relative 'ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
+require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
 
 module IdentityIdpFunctions
   class ProofResolution

--- a/source/proof_resolution_mock/lib/Gemfile
+++ b/source/proof_resolution_mock/lib/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby '~> 2.7.0'
 
+gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.7.0'
 gem 'retries'

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -1,6 +1,8 @@
-require 'proofer'
+require 'bundler/setup' if !defined?(Bundler)
 require 'faraday'
+require 'json'
 require 'retries'
+require 'proofer'
 require_relative 'resolution_mock_client'
 require_relative 'state_id_mock_client'
 require_relative 'ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -5,7 +5,7 @@ require 'retries'
 require 'proofer'
 require_relative 'resolution_mock_client'
 require_relative 'state_id_mock_client'
-require_relative 'ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
+require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
 
 module IdentityIdpFunctions
   class ProofResolutionMock


### PR DESCRIPTION
- helper layer is loaded from root path, not relative
- `bundler/setup` is required for git dependencies
- explicit aws-ssm-helper needed