### PR TITLE
Add shorter connection timeouts to Faraday, AWS::SSM::Client

### DIFF
--- a/lib/identity-idp-functions.rb
+++ b/lib/identity-idp-functions.rb
@@ -22,3 +22,4 @@ module IdentityIdpFunctions
 end
 
 require IdentityIdpFunctions.helper_path('ssm_helper')
+require IdentityIdpFunctions.helper_path('faraday_helper')

--- a/source/aws-ruby-sdk/faraday_helper.rb
+++ b/source/aws-ruby-sdk/faraday_helper.rb
@@ -1,0 +1,22 @@
+require 'faraday'
+
+module IdentityIdpFunctions
+  module FaradayHelper
+    # @return [Faraday::Connection] builds a Faraday instance with our defaults
+    def build_faraday
+      Faraday.new do |conn|
+        conn.options.timeout = 3
+        conn.options.read_timeout = 3
+        conn.options.open_timeout = 3
+        conn.options.write_timeout = 3
+      end
+    end
+
+    def faraday_retry_options
+      {
+        max_tries: 3,
+        rescue: [Faraday::TimeoutError, Faraday::ConnectionFailed],
+      }
+    end
+  end
+end

--- a/source/aws-ruby-sdk/ssm_helper.rb
+++ b/source/aws-ruby-sdk/ssm_helper.rb
@@ -11,7 +11,11 @@ module IdentityIdpFunctions
     end
 
     def ssm_client
-      @ssm_client ||= Aws::SSM::Client.new
+      @ssm_client ||= Aws::SSM::Client.new(
+        http_idle_timeout: 3,
+        http_open_timeout: 3,
+        http_read_timeout: 3,
+      )
     end
 
     # prod, dev, int, etc

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -1,13 +1,15 @@
 require 'bundler/setup' if !defined?(Bundler)
-require 'faraday'
 require 'json'
 require 'retries'
 require 'proofer'
 require 'lexisnexis'
+require '/opt/ruby/lib/faraday_helper' if !defined?(IdentityIdpFunctions::FaradayHelper)
 require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
 
 module IdentityIdpFunctions
   class ProofAddress
+    include IdentityIdpFunctions::FaradayHelper
+
     def self.handle(event:, context:, &callback_block)
       params = JSON.parse(event.to_json, symbolize_names: true)
       new(**params).proof(&callback_block)
@@ -23,7 +25,7 @@ module IdentityIdpFunctions
     def proof(&callback_block)
       set_up_env!
 
-      proofer_result = with_retries(**retry_options) do
+      proofer_result = with_retries(**faraday_retry_options) do
         lexisnexis_proofer.proof(applicant_pii)
       end
 
@@ -45,8 +47,8 @@ module IdentityIdpFunctions
     end
 
     def post_callback(callback_body:)
-      with_retries(**retry_options) do
-        Faraday.post(
+      with_retries(**faraday_retry_options) do
+        build_faraday.post(
           callback_url,
           callback_body.to_json,
           "X-API-AUTH-TOKEN" => api_auth_token,
@@ -81,13 +83,6 @@ module IdentityIdpFunctions
 
     def ssm_helper
       @ssm_helper ||= SsmHelper.new
-    end
-
-    def retry_options
-      {
-        max_tries: 3,
-        rescue: [Faraday::TimeoutError, Faraday::ConnectionFailed],
-      }
     end
   end
 end

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -1,14 +1,16 @@
 require 'bundler/setup' if !defined?(Bundler)
-require 'faraday'
 require 'json'
 require 'retries'
 require 'proofer'
 require_relative 'resolution_mock_client'
 require_relative 'state_id_mock_client'
+require '/opt/ruby/lib/faraday_helper' if !defined?(IdentityIdpFunctions::FaradayHelper)
 require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
 
 module IdentityIdpFunctions
   class ProofResolutionMock
+    include IdentityIdpFunctions::FaradayHelper
+
     def self.handle(event:, context:, &callback_block)
       params = JSON.parse(event.to_json, symbolize_names: true)
       new(**params).proof(&callback_block)
@@ -23,7 +25,7 @@ module IdentityIdpFunctions
     end
 
     def proof(&callback_block)
-      proofer_result = with_retries(**retry_options) do
+      proofer_result = with_retries(**faraday_retry_options) do
         resolution_mock_proofer.proof(applicant_pii)
       end
 
@@ -54,7 +56,7 @@ module IdentityIdpFunctions
     def proof_state_id(result)
       result[:context][:stages].push(state_id: IdentityIdpFunctions::StateIdMockClient.vendor_name)
 
-      proofer_result = with_retries(**retry_options) do
+      proofer_result = with_retries(**faraday_retry_options) do
         state_id_mock_proofer.proof(applicant_pii)
       end
 
@@ -69,8 +71,8 @@ module IdentityIdpFunctions
     end
 
     def post_callback(callback_body:)
-      with_retries(**retry_options) do
-        Faraday.post(
+      with_retries(**faraday_retry_options) do
+        build_faraday.post(
           callback_url,
           callback_body.to_json,
           "X-API-AUTH-TOKEN" => api_auth_token,
@@ -96,13 +98,6 @@ module IdentityIdpFunctions
 
     def ssm_helper
       @ssm_helper ||= SsmHelper.new
-    end
-
-    def retry_options
-      {
-        max_tries: 3,
-        rescue: [Faraday::TimeoutError, Faraday::ConnectionFailed],
-      }
     end
   end
 end


### PR DESCRIPTION
- Shorter timeouts make things easier to debug

