### PR TITLE
raise error if auth token is blank and block not given (LG-3683)

### DIFF
--- a/lib/identity-idp-functions.rb
+++ b/lib/identity-idp-functions.rb
@@ -23,4 +23,4 @@ end
 
 require IdentityIdpFunctions.helper_path('ssm_helper')
 require IdentityIdpFunctions.helper_path('faraday_helper')
-require IdentityIdpFunctions.helper_path('error_helper')
+require IdentityIdpFunctions.helper_path('errors')

--- a/lib/identity-idp-functions.rb
+++ b/lib/identity-idp-functions.rb
@@ -21,6 +21,4 @@ module IdentityIdpFunctions
   end
 end
 
-require IdentityIdpFunctions.helper_path('ssm_helper')
-require IdentityIdpFunctions.helper_path('faraday_helper')
-require IdentityIdpFunctions.helper_path('errors')
+require IdentityIdpFunctions.helper_path('function_helper')

--- a/lib/identity-idp-functions.rb
+++ b/lib/identity-idp-functions.rb
@@ -6,6 +6,12 @@ require 'identity-idp-functions/version'
 module IdentityIdpFunctions
   module_function
 
+  class MisconfiguredLambdaError < StandardError
+    def message
+      'IDP_API_AUTH_TOKEN is not configured'
+    end
+  end
+
   # Helper for building a ruby require path for
   # "source/$function_name/lib/$function_name.rb"
   def function_path(function_name)

--- a/lib/identity-idp-functions.rb
+++ b/lib/identity-idp-functions.rb
@@ -6,12 +6,6 @@ require 'identity-idp-functions/version'
 module IdentityIdpFunctions
   module_function
 
-  class MisconfiguredLambdaError < StandardError
-    def message
-      'IDP_API_AUTH_TOKEN is not configured'
-    end
-  end
-
   # Helper for building a ruby require path for
   # "source/$function_name/lib/$function_name.rb"
   def function_path(function_name)
@@ -29,3 +23,4 @@ end
 
 require IdentityIdpFunctions.helper_path('ssm_helper')
 require IdentityIdpFunctions.helper_path('faraday_helper')
+require IdentityIdpFunctions.helper_path('error_helper')

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/source/aws-ruby-sdk/error_helper.rb
+++ b/source/aws-ruby-sdk/error_helper.rb
@@ -1,7 +1,0 @@
-module IdentityIdpFunctions
-  class MisconfiguredLambdaError < StandardError
-    def message
-      'IDP_API_AUTH_TOKEN is not configured'
-    end
-  end
-end

--- a/source/aws-ruby-sdk/error_helper.rb
+++ b/source/aws-ruby-sdk/error_helper.rb
@@ -1,0 +1,7 @@
+module IdentityIdpFunctions
+  class MisconfiguredLambdaError < StandardError
+    def message
+      'IDP_API_AUTH_TOKEN is not configured'
+    end
+  end
+end

--- a/source/aws-ruby-sdk/errors.rb
+++ b/source/aws-ruby-sdk/errors.rb
@@ -1,0 +1,9 @@
+module IdentityIdpFunctions
+  module Errors
+    class MisconfiguredLambdaError < StandardError
+      def message
+        'IDP_API_AUTH_TOKEN is not configured'
+      end
+    end
+  end
+end

--- a/source/aws-ruby-sdk/function_helper.rb
+++ b/source/aws-ruby-sdk/function_helper.rb
@@ -1,0 +1,8 @@
+require_relative './faraday_helper'
+require_relative './ssm_helper'
+require_relative './errors'
+
+module IdentityIdpFunctions
+  class FunctionHelper
+  end
+end

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -25,6 +25,8 @@ module IdentityIdpFunctions
     def proof
       set_up_env!
 
+      raise MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+
       proofer_result = with_retries(**faraday_retry_options) do
         lexisnexis_proofer.proof(applicant_pii)
       end

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -25,7 +25,7 @@ module IdentityIdpFunctions
     def proof
       set_up_env!
 
-      raise MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+      raise Errors::MisconfiguredLambdaError unless block_given? || api_auth_token.present?
 
       proofer_result = with_retries(**faraday_retry_options) do
         lexisnexis_proofer.proof(applicant_pii)

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -3,8 +3,7 @@ require 'json'
 require 'retries'
 require 'proofer'
 require 'lexisnexis'
-require '/opt/ruby/lib/faraday_helper' if !defined?(IdentityIdpFunctions::FaradayHelper)
-require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
+require '/opt/ruby/lib/function_helper' if !defined?(IdentityIdpFunctions::FunctionHelper)
 
 module IdentityIdpFunctions
   class ProofAddress

--- a/source/proof_address/spec/proof_address_spec.rb
+++ b/source/proof_address/spec/proof_address_spec.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 require 'identity-idp-functions/proof_address'
+require 'shared_examples_for_proofers'
 
 RSpec.describe IdentityIdpFunctions::ProofAddress do
   let(:idp_api_auth_token) { SecureRandom.hex }
@@ -172,6 +173,12 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
 
         expect(a_request(:post, callback_url)).to have_been_made.times(3)
       end
+    end
+
+    context 'when IDP auth token is blank' do
+      let(:idp_api_auth_token) { nil }
+
+      it_behaves_like 'misconfigured proofer'
     end
 
     context 'when there are no params in the ENV' do

--- a/source/proof_address/spec/proof_address_spec.rb
+++ b/source/proof_address/spec/proof_address_spec.rb
@@ -176,8 +176,6 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
     end
 
     context 'when IDP auth token is blank' do
-      let(:idp_api_auth_token) { nil }
-
       it_behaves_like 'misconfigured proofer'
     end
 

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -23,6 +23,8 @@ module IdentityIdpFunctions
     end
 
     def proof
+      raise MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+
       proofer_result = with_retries(**faraday_retry_options) do
         mock_proofer.proof(applicant_pii)
       end

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -23,7 +23,7 @@ module IdentityIdpFunctions
     end
 
     def proof
-      raise MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+      raise Errors::MisconfiguredLambdaError unless block_given? || api_auth_token.present?
 
       proofer_result = with_retries(**faraday_retry_options) do
         mock_proofer.proof(applicant_pii)

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -3,8 +3,7 @@ require 'json'
 require 'proofer'
 require 'retries'
 require_relative 'address_mock_client'
-require '/opt/ruby/lib/faraday_helper' if !defined?(IdentityIdpFunctions::FaradayHelper)
-require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
+require '/opt/ruby/lib/function_helper' if !defined?(IdentityIdpFunctions::FunctionHelper)
 
 module IdentityIdpFunctions
   class ProofAddressMock

--- a/source/proof_address_mock/spec/proof_address_mock_spec.rb
+++ b/source/proof_address_mock/spec/proof_address_mock_spec.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 require 'identity-idp-functions/proof_address_mock'
+require 'shared_examples_for_proofers'
 
 RSpec.describe IdentityIdpFunctions::ProofAddressMock do
   let(:idp_api_auth_token) { SecureRandom.hex }
@@ -143,6 +144,12 @@ RSpec.describe IdentityIdpFunctions::ProofAddressMock do
 
         expect(a_request(:post, callback_url)).to have_been_made.times(3)
       end
+    end
+
+    context 'when IDP auth token is blank' do
+      let(:idp_api_auth_token) { nil }
+
+      it_behaves_like 'misconfigured proofer'
     end
 
     context 'when there are no params in the ENV' do

--- a/source/proof_address_mock/spec/proof_address_mock_spec.rb
+++ b/source/proof_address_mock/spec/proof_address_mock_spec.rb
@@ -147,8 +147,6 @@ RSpec.describe IdentityIdpFunctions::ProofAddressMock do
     end
 
     context 'when IDP auth token is blank' do
-      let(:idp_api_auth_token) { nil }
-
       it_behaves_like 'misconfigured proofer'
     end
 

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -27,7 +27,7 @@ module IdentityIdpFunctions
     def proof
       set_up_env!
 
-      raise MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+      raise Errors::MisconfiguredLambdaError unless block_given? || api_auth_token.present?
 
       proofer_result = with_retries(**faraday_retry_options) do
         lexisnexis_proofer.proof(applicant_pii)

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -4,8 +4,7 @@ require 'retries'
 require 'proofer'
 require 'aamva'
 require 'lexisnexis'
-require '/opt/ruby/lib/faraday_helper' if !defined?(IdentityIdpFunctions::FaradayHelper)
-require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
+require '/opt/ruby/lib/function_helper' if !defined?(IdentityIdpFunctions::FunctionHelper)
 
 module IdentityIdpFunctions
   class ProofResolution

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -27,6 +27,8 @@ module IdentityIdpFunctions
     def proof
       set_up_env!
 
+      raise MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+
       proofer_result = with_retries(**faraday_retry_options) do
         lexisnexis_proofer.proof(applicant_pii)
       end

--- a/source/proof_resolution/spec/proof_resolution_spec.rb
+++ b/source/proof_resolution/spec/proof_resolution_spec.rb
@@ -212,8 +212,6 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
     end
 
     context 'when IDP auth token is blank' do
-      let(:idp_api_auth_token) { nil }
-
       it_behaves_like 'misconfigured proofer'
     end
 

--- a/source/proof_resolution/spec/proof_resolution_spec.rb
+++ b/source/proof_resolution/spec/proof_resolution_spec.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 require 'identity-idp-functions/proof_resolution'
+require 'shared_examples_for_proofers'
 
 RSpec.describe IdentityIdpFunctions::ProofResolution do
   let(:idp_api_auth_token) { SecureRandom.hex }
@@ -208,6 +209,12 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
 
         expect(WebMock).to have_requested(:post, callback_url)
       end
+    end
+
+    context 'when IDP auth token is blank' do
+      let(:idp_api_auth_token) { nil }
+
+      it_behaves_like 'misconfigured proofer'
     end
 
     context 'when there are no params in the ENV' do

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -25,6 +25,8 @@ module IdentityIdpFunctions
     end
 
     def proof
+      raise MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+
       proofer_result = with_retries(**faraday_retry_options) do
         resolution_mock_proofer.proof(applicant_pii)
       end

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -25,7 +25,7 @@ module IdentityIdpFunctions
     end
 
     def proof
-      raise MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+      raise Errors::MisconfiguredLambdaError unless block_given? || api_auth_token.present?
 
       proofer_result = with_retries(**faraday_retry_options) do
         resolution_mock_proofer.proof(applicant_pii)

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -4,8 +4,7 @@ require 'retries'
 require 'proofer'
 require_relative 'resolution_mock_client'
 require_relative 'state_id_mock_client'
-require '/opt/ruby/lib/faraday_helper' if !defined?(IdentityIdpFunctions::FaradayHelper)
-require '/opt/ruby/lib/ssm_helper' if !defined?(IdentityIdpFunctions::SsmHelper)
+require '/opt/ruby/lib/function_helper' if !defined?(IdentityIdpFunctions::FunctionHelper)
 
 module IdentityIdpFunctions
   class ProofResolutionMock

--- a/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
+++ b/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
@@ -169,8 +169,6 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
     end
 
     context 'when IDP auth token is blank' do
-      let(:idp_api_auth_token) { nil }
-
       it_behaves_like 'misconfigured proofer'
     end
 

--- a/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
+++ b/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 require 'identity-idp-functions/proof_resolution_mock'
+require 'shared_examples_for_proofers'
 
 RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
   let(:idp_api_auth_token) { SecureRandom.hex }
@@ -165,6 +166,12 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
 
         expect(WebMock).to have_requested(:post, callback_url)
       end
+    end
+
+    context 'when IDP auth token is blank' do
+      let(:idp_api_auth_token) { nil }
+
+      it_behaves_like 'misconfigured proofer'
     end
 
     context 'when there are no params in the ENV' do

--- a/spec/shared_examples_for_proofers.rb
+++ b/spec/shared_examples_for_proofers.rb
@@ -6,7 +6,6 @@ RSpec.shared_examples 'misconfigured proofer' do
   end
 
   it 'raises error if auth token is not configured and block is not given' do
-
     expect { function.proof }.to raise_exception 'IDP_API_AUTH_TOKEN is not configured'
 
     expect(WebMock).to_not have_requested(:post, callback_url)

--- a/spec/shared_examples_for_proofers.rb
+++ b/spec/shared_examples_for_proofers.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.shared_examples 'misconfigured proofer' do
+  it 'raises error if auth token is not configured and block is not given' do
+    expect { function.proof }.to raise_exception 'IDP_API_AUTH_TOKEN is not configured'
+
+    expect(WebMock).to_not have_requested(:post, callback_url)
+  end
+end

--- a/spec/shared_examples_for_proofers.rb
+++ b/spec/shared_examples_for_proofers.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 RSpec.shared_examples 'misconfigured proofer' do
+  before do
+    ENV['IDP_API_AUTH_TOKEN'] = nil
+  end
+
   it 'raises error if auth token is not configured and block is not given' do
+
     expect { function.proof }.to raise_exception 'IDP_API_AUTH_TOKEN is not configured'
 
     expect(WebMock).to_not have_requested(:post, callback_url)


### PR DESCRIPTION
This addresses the case where the lambda could make a call to the vendor despite not being able to make the callback to the IDP