### PR TITLE
Fix implicit ActiveSupport dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ commands:
       - bundle-install
       - run:
           name: Run rspec
-          command: bundle exec rspec
+          command: bundle exec rake spec
 
   run-lints:
     steps:

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --format documentation
 --color
 --require spec_helper
---pattern "{source/,spec/}**{,/*/**}/*_spec.rb"

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -24,7 +24,7 @@ module IdentityIdpFunctions
     def proof
       set_up_env!
 
-      raise Errors::MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+      raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
 
       proofer_result = with_retries(**faraday_retry_options) do
         lexisnexis_proofer.proof(applicant_pii)

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -22,7 +22,7 @@ module IdentityIdpFunctions
     end
 
     def proof
-      raise Errors::MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+      raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
 
       proofer_result = with_retries(**faraday_retry_options) do
         mock_proofer.proof(applicant_pii)

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -26,7 +26,7 @@ module IdentityIdpFunctions
     def proof
       set_up_env!
 
-      raise Errors::MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+      raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
 
       proofer_result = with_retries(**faraday_retry_options) do
         lexisnexis_proofer.proof(applicant_pii)

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -24,7 +24,7 @@ module IdentityIdpFunctions
     end
 
     def proof
-      raise Errors::MisconfiguredLambdaError unless block_given? || api_auth_token.present?
+      raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
 
       proofer_result = with_retries(**faraday_retry_options) do
         resolution_mock_proofer.proof(applicant_pii)


### PR DESCRIPTION
We had an error in prod due to a sneaky ActiveSupport implicit dependency:

```
{
    "errorMessage": "undefined method `present?' for \"f7b7714de17eeee6ba026e1e451ee579\":String\nDid you mean?  prepend",
    "errorType": "Function<NoMethodError>",
    "stackTrace": [
        "/var/task/proof_resolution_mock.rb:27:in `proof'",
        "/var/task/proof_resolution_mock.rb:15:in `handle'"
    ]
}
```

Our test process does load ActiveSupport so this does sneaked through CI

I removed the load-all in `.rspec` which lets us run individual specs and catch this next time
