### PR TITLE
Error on 4XX or 5XX errors from the IDP

### DIFF
--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end

--- a/source/aws-ruby-sdk/faraday_helper.rb
+++ b/source/aws-ruby-sdk/faraday_helper.rb
@@ -9,6 +9,9 @@ module IdentityIdpFunctions
         conn.options.read_timeout = 3
         conn.options.open_timeout = 3
         conn.options.write_timeout = 3
+
+        # raises errors on 4XX or 5XX responses
+        conn.response :raise_error
       end
     end
 

--- a/source/proof_address/spec/proof_address_spec.rb
+++ b/source/proof_address/spec/proof_address_spec.rb
@@ -127,6 +127,8 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
 
         expect(WebMock).to have_requested(:post, callback_url)
       end
+
+      it_behaves_like 'callback url behavior'
     end
 
     context 'with an unsuccessful response from the proofer' do
@@ -154,24 +156,6 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
         expect { function.proof }.to raise_error(Faraday::ConnectionFailed)
 
         expect(WebMock).to_not have_requested(:post, callback_url)
-      end
-    end
-
-    context 'with a connection error posting to the callback url' do
-      before do
-        expect(lexisnexis_proofer).to receive(:proof).
-          and_return(Proofer::Result.new)
-
-        stub_request(:post, callback_url).
-          to_timeout.
-          to_timeout.
-          to_timeout
-      end
-
-      it 'retries 3 then errors' do
-        expect { function.proof }.to raise_error(Faraday::ConnectionFailed)
-
-        expect(a_request(:post, callback_url)).to have_been_made.times(3)
       end
     end
 

--- a/source/proof_address_mock/spec/proof_address_mock_spec.rb
+++ b/source/proof_address_mock/spec/proof_address_mock_spec.rb
@@ -131,20 +131,7 @@ RSpec.describe IdentityIdpFunctions::ProofAddressMock do
       end
     end
 
-    context 'with a connection error posting to the callback url' do
-      before do
-        stub_request(:post, callback_url).
-          to_timeout.
-          to_timeout.
-          to_timeout
-      end
-
-      it 'retries 3 then errors' do
-        expect { function.proof }.to raise_error(Faraday::ConnectionFailed)
-
-        expect(a_request(:post, callback_url)).to have_been_made.times(3)
-      end
-    end
+    it_behaves_like 'callback url behavior'
 
     context 'when IDP auth token is blank' do
       it_behaves_like 'misconfigured proofer'

--- a/source/proof_resolution/spec/proof_resolution_spec.rb
+++ b/source/proof_resolution/spec/proof_resolution_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
 
         expect(aamva_proofer).to receive(:proof).
           and_return(Proofer::Result.new)
-        end
+      end
 
       it 'posts back to the callback url' do
         function.proof

--- a/source/proof_resolution/spec/proof_resolution_spec.rb
+++ b/source/proof_resolution/spec/proof_resolution_spec.rb
@@ -138,17 +138,21 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
     end
 
     context 'with a successful response from the proofer' do
-      it 'posts back to the callback url' do
+      before do
         expect(lexisnexis_proofer).to receive(:proof).
           and_return(Proofer::Result.new)
 
         expect(aamva_proofer).to receive(:proof).
           and_return(Proofer::Result.new)
+        end
 
+      it 'posts back to the callback url' do
         function.proof
 
         expect(WebMock).to have_requested(:post, callback_url)
       end
+
+      it_behaves_like 'callback url behavior'
     end
 
     context 'does not call state id with an unsuccessful response from the proofer' do
@@ -173,27 +177,6 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
 
       it 'retries 3 times then errors' do
         expect(WebMock).to_not have_requested(:post, callback_url)
-      end
-    end
-
-    context 'with a connection error posting to the callback url' do
-      before do
-        expect(lexisnexis_proofer).to receive(:proof).
-          and_return(Proofer::Result.new)
-
-        expect(aamva_proofer).to receive(:proof).
-          and_return(Proofer::Result.new)
-
-        stub_request(:post, callback_url).
-          to_timeout.
-          to_timeout.
-          to_timeout
-      end
-
-      it 'retries 3 then errors' do
-        expect { function.proof }.to raise_error(Faraday::ConnectionFailed)
-
-        expect(a_request(:post, callback_url)).to have_been_made.times(3)
       end
     end
 

--- a/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
+++ b/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
@@ -142,21 +142,6 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
       end
     end
 
-    context 'with a connection error posting to the callback url' do
-      before do
-        stub_request(:post, callback_url).
-          to_timeout.
-          to_timeout.
-          to_timeout
-      end
-
-      it 'retries 3 then errors' do
-        expect { function.proof }.to raise_error(Faraday::ConnectionFailed)
-
-        expect(a_request(:post, callback_url)).to have_been_made.times(3)
-      end
-    end
-
     context 'no state_id proof' do
       let(:should_proof_state_id) { false }
 
@@ -167,6 +152,8 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
         expect(WebMock).to have_requested(:post, callback_url)
       end
     end
+
+    it_behaves_like 'callback url behavior'
 
     context 'when IDP auth token is blank' do
       it_behaves_like 'misconfigured proofer'

--- a/spec/shared_examples_for_proofers.rb
+++ b/spec/shared_examples_for_proofers.rb
@@ -11,3 +11,33 @@ RSpec.shared_examples 'misconfigured proofer' do
     expect(WebMock).to_not have_requested(:post, callback_url)
   end
 end
+
+RSpec.shared_examples 'callback url behavior' do
+  context 'with a connection error posting to the callback url' do
+    before do
+      stub_request(:post, callback_url).
+        to_timeout.
+        to_timeout.
+        to_timeout
+    end
+
+    it 'retries 3 then errors' do
+      expect { function.proof }.to raise_error(Faraday::ConnectionFailed)
+
+      expect(a_request(:post, callback_url)).to have_been_made.times(3)
+    end
+  end
+
+  context 'with a non-200 response posting to the callback url' do
+    before do
+      stub_request(:post, callback_url).
+        to_return(status: 401)
+    end
+
+    it 'errors immediately' do
+      expect { function.proof }.to raise_error(Faraday::UnauthorizedError)
+
+      expect(a_request(:post, callback_url)).to have_been_made.once
+    end
+  end
+end


### PR DESCRIPTION
I discovered that 401's from the IDP were considered successful lambda runs.... which is incorrect