### PR TITLE
Switch to a shared path per-env for IdP function secrets

### DIFF
--- a/source/aws-ruby-sdk/ssm_helper.rb
+++ b/source/aws-ruby-sdk/ssm_helper.rb
@@ -5,7 +5,7 @@ module IdentityIdpFunctions
     # @return [String]
     def load(parameter_name)
       ssm_client.get_parameter(
-        name: "/#{env_name}/idp/doc-capture/#{parameter_name}",
+        name: "/#{env_name}/idp/functions/#{parameter_name}",
         with_decryption: true,
       ).parameter.value
     end


### PR DESCRIPTION
This matches the change in https://github.com/18F/identity-devops/pull/3061
to have one shared set of SSM params per-environment for all IdP functions.

If we need to have different functions access subsets of params later we
can add it.  There does not appear to be a need.