### PR TITLE
Logging, Timing, Tracing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -462,3 +462,8 @@ Style/NegatedIf:
 Style/IfUnlessModifier:
   # Differs from IDP
   Enabled: false
+
+Style/GlobalVars:
+  Enabled: true
+  Exclude:
+    - '**/spec/**'

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.5.4'
+  VERSION = '0.6.0'
 end

--- a/source/aws-ruby-sdk/function_helper.rb
+++ b/source/aws-ruby-sdk/function_helper.rb
@@ -1,6 +1,8 @@
-require_relative './faraday_helper'
-require_relative './ssm_helper'
 require_relative './errors'
+require_relative './faraday_helper'
+require_relative './logging_helper'
+require_relative './ssm_helper'
+require_relative './timer'
 
 module IdentityIdpFunctions
   class FunctionHelper

--- a/source/aws-ruby-sdk/logging_helper.rb
+++ b/source/aws-ruby-sdk/logging_helper.rb
@@ -1,0 +1,33 @@
+require 'json'
+require 'time'
+require 'logger'
+
+module IdentityIdpFunctions
+  module LoggingHelper
+    def log_event(name:, level: Logger::INFO, **key_values)
+      int_level = level.is_a?(Integer) ? level : Logger.const_get(level.to_s.upcase)
+
+      payload = { name: name }.merge(key_values)
+      logger.log(int_level, payload)
+    end
+
+    def logger(io: default_logger_io, level: Logger::INFO)
+      @logger ||= Logger.new(io).tap do |logger|
+        logger.level = level
+        logger.formatter = proc do |severity, datetime, _progname, msg|
+          payload = msg.is_a?(Hash) ? msg : { message: msg }
+
+          payload.merge(
+            time: datetime.iso8601,
+            level: severity,
+          ).to_json + "\n"
+        end
+      end
+    end
+
+    # This is just a hook so we can override this in specs to not barf to STDOUT
+    def default_logger_io
+      STDOUT
+    end
+  end
+end

--- a/source/aws-ruby-sdk/timer.rb
+++ b/source/aws-ruby-sdk/timer.rb
@@ -1,0 +1,19 @@
+require 'time'
+
+module IdentityIdpFunctions
+  class Timer
+    attr_reader :results
+
+    def initialize
+      @results = {}
+    end
+
+    def time(name)
+      start = Time.now.to_f
+
+      yield
+    ensure
+      results[name] = ((Time.now.to_f - start) * 1000).round(2)
+    end
+  end
+end

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -57,7 +57,7 @@ module IdentityIdpFunctions
         name: 'ProofAddress',
         trace_id: trace_id,
         success: proofer_result.success?,
-        timing: timer.results
+        timing: timer.results,
       )
     end
 

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -52,11 +52,11 @@ module IdentityIdpFunctions
           post_callback(callback_body: callback_body)
         end
       end
-
+    ensure
       log_event(
         name: 'ProofAddress',
         trace_id: trace_id,
-        success: proofer_result.success?,
+        success: proofer_result&.success?,
         timing: timer.results,
       )
     end

--- a/source/proof_address/spec/proof_address_spec.rb
+++ b/source/proof_address/spec/proof_address_spec.rb
@@ -5,6 +5,7 @@ require 'shared_examples_for_proofers'
 RSpec.describe IdentityIdpFunctions::ProofAddress do
   let(:idp_api_auth_token) { SecureRandom.hex }
   let(:callback_url) { 'https://example.login.gov/api/callbacks/proof-address/:token' }
+  let(:trace_id) { SecureRandom.uuid }
   let(:applicant_pii) do
     {
       first_name: 'Johnny',
@@ -64,6 +65,7 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
       {
         callback_url: callback_url,
         applicant_pii: applicant_pii,
+        trace_id: trace_id,
       }
     end
 
@@ -104,6 +106,7 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
       IdentityIdpFunctions::ProofAddress.new(
         callback_url: callback_url,
         applicant_pii: applicant_pii,
+        trace_id: trace_id,
       )
     end
 
@@ -129,6 +132,12 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
       end
 
       it_behaves_like 'callback url behavior'
+
+      it 'logs the trace_id and timing info' do
+        expect(function).to receive(:log_event).with(hash_including(:timing, trace_id: trace_id))
+
+        function.proof
+      end
     end
 
     context 'with an unsuccessful response from the proofer' do

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -55,7 +55,7 @@ module IdentityIdpFunctions
         name: 'ProofAddressMock',
         trace_id: trace_id,
         success: proofer_result.success?,
-        timing: timer.results
+        timing: timer.results,
       )
     end
 

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -27,8 +27,10 @@ module IdentityIdpFunctions
     def proof
       raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
 
-      proofer_result = with_retries(**faraday_retry_options) do
-        mock_proofer.proof(applicant_pii)
+      proofer_result = timer.time('address') do
+        with_retries(**faraday_retry_options) do
+          mock_proofer.proof(applicant_pii)
+        end
       end
 
       result = proofer_result.to_h

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -50,11 +50,11 @@ module IdentityIdpFunctions
           post_callback(callback_body: callback_body)
         end
       end
-
+    ensure
       log_event(
         name: 'ProofAddressMock',
         trace_id: trace_id,
-        success: proofer_result.success?,
+        success: proofer_result&.success?,
         timing: timer.results,
       )
     end

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -9,18 +9,21 @@ require '/opt/ruby/lib/function_helper' if !defined?(IdentityIdpFunctions::Funct
 module IdentityIdpFunctions
   class ProofResolution
     include IdentityIdpFunctions::FaradayHelper
+    include IdentityIdpFunctions::LoggingHelper
 
     def self.handle(event:, context:, &callback_block) # rubocop:disable Lint/UnusedMethodArgument
       params = JSON.parse(event.to_json, symbolize_names: true)
       new(**params).proof(&callback_block)
     end
 
-    attr_reader :applicant_pii, :callback_url, :should_proof_state_id
+    attr_reader :applicant_pii, :callback_url, :should_proof_state_id, :trace_id, :timer
 
-    def initialize(applicant_pii:, callback_url:, should_proof_state_id:)
+    def initialize(applicant_pii:, callback_url:, should_proof_state_id:, trace_id: nil)
       @applicant_pii = applicant_pii
       @callback_url = callback_url
       @should_proof_state_id = should_proof_state_id
+      @trace_id = trace_id
+      @timer = IdentityIdpFunctions::Timer.new
     end
 
     def proof
@@ -28,19 +31,26 @@ module IdentityIdpFunctions
 
       raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
 
-      proofer_result = with_retries(**faraday_retry_options) do
-        lexisnexis_proofer.proof(applicant_pii)
+      proofer_result = timer.time('resolution') do
+        with_retries(**faraday_retry_options) do
+          lexisnexis_proofer.proof(applicant_pii)
+        end
       end
 
       result = proofer_result.to_h
+      resolution_success = proofer_result.success?
 
       result[:context] = { stages: [resolution: LexisNexis::InstantVerify::Proofer.vendor_name] }
 
       result[:timed_out] = proofer_result.timed_out?
       result[:exception] = proofer_result.exception.inspect if proofer_result.exception
 
+      state_id_success = nil
       if should_proof_state_id && result[:success]
-        proof_state_id(result)
+        timer.time('state_id') do
+          proof_state_id(result)
+        end
+        state_id_success = result[:success]
       end
 
       callback_body = {
@@ -52,6 +62,14 @@ module IdentityIdpFunctions
       else
         post_callback(callback_body: callback_body)
       end
+
+      log_event(
+        name: 'ProofResolution',
+        trace_id: trace_id,
+        resolution_success: resolution_success,
+        state_id_success: state_id_success,
+        timing: timer.results
+      )
     end
 
     def proof_state_id(result)

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -62,7 +62,7 @@ module IdentityIdpFunctions
       else
         post_callback(callback_body: callback_body)
       end
-
+    ensure
       log_event(
         name: 'ProofResolution',
         trace_id: trace_id,

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -68,7 +68,7 @@ module IdentityIdpFunctions
         trace_id: trace_id,
         resolution_success: resolution_success,
         state_id_success: state_id_success,
-        timing: timer.results
+        timing: timer.results,
       )
     end
 

--- a/source/proof_resolution/spec/proof_resolution_spec.rb
+++ b/source/proof_resolution/spec/proof_resolution_spec.rb
@@ -5,6 +5,7 @@ require 'shared_examples_for_proofers'
 RSpec.describe IdentityIdpFunctions::ProofResolution do
   let(:idp_api_auth_token) { SecureRandom.hex }
   let(:callback_url) { 'https://example.login.gov/api/callbacks/proof-resolution/:token' }
+  let(:trace_id) { SecureRandom.uuid }
   let(:applicant_pii) do
     {
       first_name: 'Johnny',
@@ -78,6 +79,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
         callback_url: callback_url,
         should_proof_state_id: true,
         applicant_pii: applicant_pii,
+        trace_id: trace_id,
       }
     end
 
@@ -126,6 +128,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
         callback_url: callback_url,
         applicant_pii: applicant_pii,
         should_proof_state_id: should_proof_state_id,
+        trace_id: trace_id,
       )
     end
 
@@ -153,6 +156,12 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
       end
 
       it_behaves_like 'callback url behavior'
+
+      it 'logs the trace_id and timing info' do
+        expect(function).to receive(:log_event).with(hash_including(:timing, trace_id: trace_id))
+
+        function.proof
+      end
     end
 
     context 'does not call state id with an unsuccessful response from the proofer' do

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -57,10 +57,11 @@ module IdentityIdpFunctions
         end
       end
 
+    ensure
       log_event(
         name: 'ProofResolutionMock',
         trace_id: trace_id,
-        success: proofer_result.success?,
+        success: proofer_result&.success?,
         timing: timer.results,
       )
     end

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -61,7 +61,7 @@ module IdentityIdpFunctions
         name: 'ProofResolutionMock',
         trace_id: trace_id,
         success: proofer_result.success?,
-        timing: timer.results
+        timing: timer.results,
       )
     end
 

--- a/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
+++ b/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
   let(:callback_url) { 'https://example.login.gov/api/callbacks/proof-resolution/:token' }
   let(:ssn) { '123456789' }
   let(:bad_ssn) { IdentityIdpFunctions::ResolutionMockClient::NO_CONTACT_SSN }
+  let(:trace_id) { SecureRandom.uuid }
   let(:applicant_pii) do
     {
       first_name: 'Johnny',
@@ -59,6 +60,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
         callback_url: callback_url,
         should_proof_state_id: true,
         applicant_pii: applicant_pii,
+        trace_id: trace_id,
       }
     end
 
@@ -103,6 +105,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
         callback_url: callback_url,
         applicant_pii: applicant_pii,
         should_proof_state_id: should_proof_state_id,
+        trace_id: trace_id,
       )
     end
 
@@ -117,6 +120,12 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
 
         expect(WebMock).to have_requested(:post, callback_url)
       end
+    end
+
+    it 'logs the trace_id and timing info' do
+      expect(function).to receive(:log_event).with(hash_including(:timing, trace_id: trace_id))
+
+      function.proof
     end
 
     context 'does not call state id with an unsuccessful response from the proofer' do

--- a/spec/lib/logging_helper_spec.rb
+++ b/spec/lib/logging_helper_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+RSpec.describe IdentityIdpFunctions::LoggingHelper do
+  let(:io) { StringIO.new }
+
+  subject(:instance) do
+    klass = Class.new do
+      include IdentityIdpFunctions::LoggingHelper
+    end
+
+    klass.new.tap do |instance|
+      instance.logger(io: io)
+    end
+  end
+
+  describe '#log_event' do
+    it 'logs a named event as JSON' do
+      instance.log_event(name: 'foobar')
+
+      json = JSON.parse(io.string, symbolize_names: true)
+      expect(json[:name]).to eq('foobar')
+    end
+
+    it 'logs extra keyword arguments in JSON' do
+      instance.log_event(name: 'foobar', count: 1, color: 'red')
+
+      json = JSON.parse(io.string, symbolize_names: true)
+      expect(json[:count]).to eq(1)
+      expect(json[:color]).to eq('red')
+    end
+
+    it 'can accept a different log level' do
+      instance.log_event(level: :warn, name: 'foobar')
+      instance.log_event(level: Logger::WARN, name: 'foobar')
+
+      io.string.lines.each do |line|
+        json = JSON.parse(line, symbolize_names: true)
+        expect(json[:level]).to eq('WARN')
+      end
+    end
+  end
+
+  describe '#logger' do
+    it 'merges hashes in to the payload' do
+      instance.logger.info(foobar: true)
+
+      json = JSON.parse(io.string, symbolize_names: true)
+      expect(json[:foobar]).to eq(true)
+    end
+
+    it 'turns strings into a message key' do
+      instance.logger.info('string')
+
+      json = JSON.parse(io.string, symbolize_names: true)
+      expect(json[:message]).to eq('string')
+    end
+
+    it 'logs the time as an ISO8601' do
+      instance.logger.warn('now')
+
+      json = JSON.parse(io.string, symbolize_names: true)
+      expect(Time.parse(json[:time]).to_i).to be_within(2).of(Time.now.to_i)
+    end
+
+    it 'logs the level' do
+      instance.logger.fatal('now')
+
+      json = JSON.parse(io.string, symbolize_names: true)
+      expect(json[:level]).to eq('FATAL')
+    end
+  end
+end

--- a/spec/lib/timer_spec.rb
+++ b/spec/lib/timer_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe IdentityIdpFunctions::Timer do
+  subject(:timer) do
+    IdentityIdpFunctions::Timer.new
+  end
+
+  describe '#time' do
+    before do
+      allow(Time).to receive(:now).and_return(1111.01, 1112.02)
+    end
+
+    it 'measures the time in milliseconds it takes to execute a block' do
+      timer.time('event') { 1 }
+
+      expect(timer.results['event']).to eq(1010.0)
+    end
+
+    it 'measure the block even if the block raises' do
+      expect do
+        timer.time('event') { raise 'boom' }
+      end.to raise_error('boom')
+
+      expect(timer.results['event']).to eq(1010.0)
+    end
+
+    it 'returns the result of the block' do
+      result = timer.time('event') { 100 }
+      expect(result).to eq(100)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'identity-idp-functions'
 require 'webmock/rspec'
 require 'retries'
+require 'stringio'
 
 Retries.sleep_enabled = false
 
@@ -14,5 +15,18 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:each) do
+    $logger_io = StringIO.new
+  end
+end
+
+# Monkeypatch to override logging to STDOUT in tests
+module IdentityIdpFunctions
+  module LoggingHelper
+    def default_logger_io
+      $logger_io
+    end
   end
 end


### PR DESCRIPTION
This adds:
- JSON-formatted logging to our lambdas (to STDOUT), matches `events.log` format in the IDP
- Logging of trace IDs (assuming we pass an explicit `trace_id` param from the IDP)
- Timing information for talking to vendors
   - If we have to retry, do we want to log each call separately? For now, no


Is there anything else we want to log?

I need to do a thorough second pass to make sure I instrumented all 4 lambdas right, but this is a first pass 


Example log lines:

```json
{"name":"ProofResolutionMock","trace_id":"b1f39e38-4dd0-451a-9be7-11ff1625f1e2","success":true,"timing":{"callback":10.37},"time":"2020-11-19T17:51:25-08:00","level":"INFO"}
{"name":"ProofResolution","trace_id":"c9b2ee50-aa37-4bb4-992b-14cfad17f831","resolution_success":true,"state_id_success":true,"timing":{"resolution":0.07,"state_id":0.04},"time":"2020-11-19T17:51:25-08:00","level":"INFO"}

```