### PR TITLE
Use lowercase env vars so that Ruby's Net::HTTP doesn't warn

### DIFF
--- a/source/template.yaml.erb
+++ b/source/template.yaml.erb
@@ -40,13 +40,13 @@ Globals:
     Runtime: ruby2.7
     Environment:
       Variables:
-        HTTP_PROXY: !Sub
+        http_proxy: !Sub
           - '{{resolve:ssm:/${Environment}/network/outboundproxy/url:1}}'
           - Environment: !Ref environment
-        HTTPS_PROXY: !Sub
+        https_proxy: !Sub
           - '{{resolve:ssm:/${Environment}/network/outboundproxy/url:1}}'
           - Environment: !Ref environment
-        NO_PROXY: !Sub
+        no_proxy: !Sub
           - '{{resolve:ssm:/${Environment}/network/outboundproxy/no_proxy:1}}'
           - Environment: !Ref environment
         ENVIRONMENT_NAME: !Ref environment


### PR DESCRIPTION
we get warnings like these:

```
/var/lang/lib/ruby/2.7.0/net/http.rb:1122: warning: The environment variable HTTP_PROXY is discouraged.  Use http_proxy.
/var/lang/lib/ruby/2.7.0/net/http.rb:1122: warning: The environment variable HTTP_PROXY is discouraged.  Use http_proxy.
/var/lang/lib/ruby/2.7.0/net/http.rb:1122: warning: The environment variable HTTP_PROXY is discouraged.  Use http_proxy.
```

See source @ https://github.com/ruby/ruby/blob/master/lib/uri/generic.rb#L1474-L1489