### PR TITLE
Update identity-doc-auth version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
-gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.0'
+gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.1'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.4.1'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.7.0'
 

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.7.3'
+  VERSION = '0.7.4'
 end

--- a/source/proof_document/lib/Gemfile
+++ b/source/proof_document/lib/Gemfile
@@ -4,6 +4,6 @@ ruby '~> 2.7.0'
 
 gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
-gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.0'
+gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.1'
 gem 'openssl'
 gem 'retries'

--- a/source/proof_document_mock/lib/Gemfile
+++ b/source/proof_document_mock/lib/Gemfile
@@ -4,6 +4,6 @@ ruby '~> 2.7.0'
 
 gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
-gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.0'
+gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.1'
 gem 'openssl'
 gem 'retries'


### PR DESCRIPTION
Ahead of updating to make the doc verification async, to match https://github.com/18F/identity-idp/pull/4461