### PR TITLE
Update mock document proofer to be able to substitute local URLs for S3

### DIFF
--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.7.4'
+  VERSION = '0.7.5'
 end

--- a/source/aws-ruby-sdk/s3_helper.rb
+++ b/source/aws-ruby-sdk/s3_helper.rb
@@ -2,6 +2,10 @@ require 'aws-sdk-s3'
 
 module IdentityIdpFunctions
   class S3Helper
+    def s3_url?(url)
+      URI.parse(url).host.split('.').include?('s3')
+    end
+
     def download(url)
       uri = URI.parse(url)
       if uri.host.start_with?('s3.')

--- a/source/proof_document/lib/proof_document.rb
+++ b/source/proof_document/lib/proof_document.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup' if !defined?(Bundler)
+require 'base64'
 require 'faraday'
 require 'identity-doc-auth'
 require 'json'
@@ -31,10 +32,10 @@ module IdentityIdpFunctions
                    liveness_checking_enabled:,
                    callback_url:,
                    trace_id: nil)
-      @encryption_key = encryption_key
-      @front_image_iv = front_image_iv
-      @back_image_iv = back_image_iv
-      @selfie_image_iv = selfie_image_iv
+      @encryption_key = Base64.decode64(encryption_key.to_s)
+      @front_image_iv = Base64.decode64(front_image_iv.to_s)
+      @back_image_iv = Base64.decode64(back_image_iv.to_s)
+      @selfie_image_iv = Base64.decode64(selfie_image_iv.to_s)
       @front_image_url = front_image_url
       @back_image_url = back_image_url
       @selfie_image_url = selfie_image_url

--- a/source/proof_document/spec/proof_document_spec.rb
+++ b/source/proof_document/spec/proof_document_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe IdentityIdpFunctions::ProofDocument do
   let(:trace_id) { SecureRandom.uuid }
   let(:event) do
     {
-      encryption_key: encryption_key,
-      front_image_iv: front_image_iv,
-      back_image_iv: back_image_iv,
-      selfie_image_iv: selfie_image_iv,
+      encryption_key: Base64.encode64(encryption_key),
+      front_image_iv: Base64.encode64(front_image_iv),
+      back_image_iv: Base64.encode64(back_image_iv),
+      selfie_image_iv: Base64.encode64(selfie_image_iv),
       front_image_url: front_image_url,
       back_image_url: back_image_url,
       selfie_image_url: selfie_image_url,

--- a/source/proof_document/spec/proof_document_spec.rb
+++ b/source/proof_document/spec/proof_document_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe IdentityIdpFunctions::ProofDocument do
   let(:front_image_iv) { '123456789012' }
   let(:back_image_iv) { '123456789012' }
   let(:selfie_image_iv) { '123456789012' }
-  let(:front_image_url) { 'http://foo.com/bar1' }
-  let(:back_image_url) { 'http://foo.com/bar2' }
-  let(:selfie_image_url) { 'http://foo.com/bar3' }
+  let(:front_image_url) { 'http://bucket.s3.amazonaws.com/bar1' }
+  let(:back_image_url) { 'http://bucket.s3.amazonaws.com/bar2' }
+  let(:selfie_image_url) { 'http://bucket.s3.amazonaws.com/bar3' }
 
   let(:applicant_pii) do
     {

--- a/source/proof_document_mock/lib/proof_document_mock.rb
+++ b/source/proof_document_mock/lib/proof_document_mock.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup' if !defined?(Bundler)
+require 'base64'
 require 'faraday'
 require 'identity-doc-auth'
 require 'json'
@@ -32,10 +33,10 @@ module IdentityIdpFunctions
                    callback_url:,
                    trace_id: nil)
       @callback_url = callback_url
-      @encryption_key = encryption_key
-      @front_image_iv = front_image_iv
-      @back_image_iv = back_image_iv
-      @selfie_image_iv = selfie_image_iv
+      @encryption_key = Base64.decode64(encryption_key.to_s)
+      @front_image_iv = Base64.decode64(front_image_iv.to_s)
+      @back_image_iv = Base64.decode64(back_image_iv.to_s)
+      @selfie_image_iv = Base64.decode64(selfie_image_iv.to_s)
       @front_image_url = front_image_url
       @back_image_url = back_image_url
       @selfie_image_url = selfie_image_url

--- a/source/proof_document_mock/lib/proof_document_mock.rb
+++ b/source/proof_document_mock/lib/proof_document_mock.rb
@@ -122,7 +122,13 @@ module IdentityIdpFunctions
     end
 
     def decrypt_from_s3(name, url, iv)
-      encrypted_image = timer.time("download.#{name}") { s3_helper.download(url) }
+      encrypted_image = timer.time("download.#{name}") do
+        if s3_helper.s3_url?(url)
+          s3_helper.download(url)
+        else
+          build_faraday.get(url).body.b
+        end
+      end
       timer.time("decrypt.#{name}") do
         encryption_helper.decrypt(data: encrypted_image, iv: iv, key: encryption_key)
       end

--- a/source/proof_document_mock/spec/proof_document_mock_spec.rb
+++ b/source/proof_document_mock/spec/proof_document_mock_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe IdentityIdpFunctions::ProofDocumentMock do
 
   let(:event) do
     {
-      encryption_key: encryption_key,
-      front_image_iv: front_image_iv,
-      back_image_iv: back_image_iv,
-      selfie_image_iv: selfie_image_iv,
+      encryption_key: Base64.encode64(encryption_key),
+      front_image_iv: Base64.encode64(front_image_iv),
+      back_image_iv: Base64.encode64(back_image_iv),
+      selfie_image_iv: Base64.encode64(selfie_image_iv),
       front_image_url: front_image_url,
       back_image_url: back_image_url,
       selfie_image_url: selfie_image_url,
@@ -33,9 +33,9 @@ RSpec.describe IdentityIdpFunctions::ProofDocumentMock do
   end
 
   let(:encryption_key) { '12345678901234567890123456789012' }
-  let(:front_image_iv) { '111111111111' }
-  let(:back_image_iv) { '222222222222' }
-  let(:selfie_image_iv) { '333333333333' }
+  let(:front_image_iv) { SecureRandom.random_bytes(12) }
+  let(:back_image_iv) { SecureRandom.random_bytes(12) }
+  let(:selfie_image_iv) { SecureRandom.random_bytes(12) }
   let(:front_image_url) { 'http://bucket.s3.amazonaws.com/bar1' }
   let(:back_image_url) { 'http://bucket.s3.amazonaws.com/bar2' }
   let(:selfie_image_url) { 'http://bucket.s3.amazonaws.com/bar3' }
@@ -100,10 +100,10 @@ RSpec.describe IdentityIdpFunctions::ProofDocumentMock do
     subject(:function) do
       IdentityIdpFunctions::ProofDocumentMock.new(
         callback_url: callback_url,
-        encryption_key: encryption_key,
-        front_image_iv: front_image_iv,
-        back_image_iv: back_image_iv,
-        selfie_image_iv: selfie_image_iv,
+        encryption_key: Base64.encode64(encryption_key),
+        front_image_iv: Base64.encode64(front_image_iv),
+        back_image_iv: Base64.encode64(back_image_iv),
+        selfie_image_iv: Base64.encode64(selfie_image_iv),
         front_image_url: front_image_url,
         back_image_url: back_image_url,
         selfie_image_url: selfie_image_url,

--- a/source/proof_document_mock/spec/proof_document_mock_spec.rb
+++ b/source/proof_document_mock/spec/proof_document_mock_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe IdentityIdpFunctions::ProofDocumentMock do
         )
       end
 
-      it 'still downloads and encrypts the content' do
+      it 'still downloads and decrypts the content' do
         function.proof
 
         expect(a_request(:get, front_image_url)).to have_been_made

--- a/spec/lib/s3_helper_spec.rb
+++ b/spec/lib/s3_helper_spec.rb
@@ -4,6 +4,32 @@ require 'securerandom'
 RSpec.describe IdentityIdpFunctions::S3Helper do
   subject(:s3_helper) { IdentityIdpFunctions::S3Helper.new }
 
+  describe '#s3_url?' do
+    subject(:s3_url?) { s3_helper.s3_url?(url) }
+
+    context 'with a subdomain bucket format url' do
+      let(:url) { 'https://s3.region-name.amazonaws.com/bucket/key' }
+      it { is_expected.to eq(true)}
+    end
+
+    context 'with a path bucket format url' do
+      let(:url) { 'https://bucket.s3.region-name.amazonaws.com/key' }
+      it { is_expected.to eq(true)}
+    end
+
+    context 'with a non-s3 url' do
+      let(:url) { 'https://example.com' }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with a non-s3 url that has an s3 subdomain' do
+      let(:url) { 'https://s3.example.com' }
+      it 'gets fooled and returns true' do
+        expect(s3_url?).to eq(true)
+      end
+    end
+  end
+
   describe '#download' do
     let(:bucket_name) { 'bucket123456' }
     let(:prefix) { SecureRandom.uuid }

--- a/spec/lib/s3_helper_spec.rb
+++ b/spec/lib/s3_helper_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe IdentityIdpFunctions::S3Helper do
 
     context 'with a subdomain bucket format url' do
       let(:url) { 'https://s3.region-name.amazonaws.com/bucket/key' }
-      it { is_expected.to eq(true)}
+      it { is_expected.to eq(true) }
     end
 
     context 'with a path bucket format url' do
       let(:url) { 'https://bucket.s3.region-name.amazonaws.com/key' }
-      it { is_expected.to eq(true)}
+      it { is_expected.to eq(true) }
     end
 
     context 'with a non-s3 url' do


### PR DESCRIPTION
The "plain" HTTP get This is only for the mock proofer, and only for local development and test cases

The Base64 changes are needed for both normal and mock proofers

