### PR TITLE
Make sure to send pii_from_doc in ProofDocument, ProofDocumentMock

### DIFF
--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.7.5'
+  VERSION = '0.7.6'
 end

--- a/source/proof_document/lib/proof_document.rb
+++ b/source/proof_document/lib/proof_document.rb
@@ -63,7 +63,8 @@ module IdentityIdpFunctions
         end
       end
 
-      result = proofer_result.to_h
+      # pii_from_doc is excluded from to_h to prevent accidental logging
+      result = proofer_result.to_h.merge(pii_from_doc: proofer_result.pii_from_doc)
 
       result[:exception] = proofer_result.exception.inspect if proofer_result.exception
 

--- a/source/proof_document/spec/proof_document_spec.rb
+++ b/source/proof_document/spec/proof_document_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe IdentityIdpFunctions::ProofDocument do
               result: 'Passed',
               success: true,
               exception: nil,
+              pii_from_doc: applicant_pii,
             },
           )
         end
@@ -138,6 +139,7 @@ RSpec.describe IdentityIdpFunctions::ProofDocument do
             success: true,
             liveness_assessment: 'Live',
             exception: nil,
+            pii_from_doc: applicant_pii,
           },
         )
 

--- a/source/proof_document_mock/lib/proof_document_mock.rb
+++ b/source/proof_document_mock/lib/proof_document_mock.rb
@@ -64,7 +64,8 @@ module IdentityIdpFunctions
         end
       end
 
-      result = proofer_result.to_h
+      # pii_from_doc is excluded from to_h to prevent accidental logging
+      result = proofer_result.to_h.merge(pii_from_doc: proofer_result.pii_from_doc)
 
       result[:exception] = proofer_result.exception.inspect if proofer_result.exception
 


### PR DESCRIPTION
**Why**: GetResultsResponse#to_h (from identity-doc-auth)
intentionally excludes to prevent accidental logging

@aduth's comment (https://github.com/18F/identity-idp/pull/4464#discussion_r531635394) prompted me to check in why we weren't receiving PII, and the answer was because we exclude PII from `#to_h` intentionally: https://github.com/18F/identity-doc-auth/blob/ac9f43820717343788ea6e0dfb9f75f8ec610f8d/lib/identity_doc_auth/acuant/responses/get_results_response.rb#L27-L40

