### PR TITLE
Move encrypt method onto EncryptionHelper so we can use it downstream

### DIFF
--- a/source/aws-ruby-sdk/encryption_helper.rb
+++ b/source/aws-ruby-sdk/encryption_helper.rb
@@ -12,5 +12,18 @@ module IdentityIdpFunctions
 
       cipher.update(data[0..-17]) + cipher.final
     end
+
+    def encrypt(data:, iv:, key:)
+      cipher = OpenSSL::Cipher.new('aes-256-gcm')
+      cipher.encrypt
+      cipher.iv = iv
+      cipher.key = key
+      cipher.auth_data = ''
+
+      encrypted = cipher.update(data) + cipher.final
+      tag = cipher.auth_tag # produces 16 bytes tag by default
+
+      encrypted + tag
+    end
   end
 end

--- a/source/proof_document_mock/spec/proof_document_mock_spec.rb
+++ b/source/proof_document_mock/spec/proof_document_mock_spec.rb
@@ -195,15 +195,17 @@ RSpec.describe IdentityIdpFunctions::ProofDocumentMock do
       let(:selfie_image_url) { 'http://example.com/bar3' }
 
       before do
-        stub_request(:get, front_image_url).to_return(
-          body: encrypt(data: applicant_pii.to_json, key: encryption_key, iv: front_image_iv),
-        )
-        stub_request(:get, back_image_url).to_return(
-          body: encrypt(data: applicant_pii.to_json, key: encryption_key, iv: back_image_iv),
-        )
-        stub_request(:get, selfie_image_url).to_return(
-          body: encrypt(data: applicant_pii.to_json, key: encryption_key, iv: selfie_image_iv),
-        )
+        encryption_helper = IdentityIdpFunctions::EncryptionHelper.new
+
+        stub_request(:get, front_image_url).to_return(body: encryption_helper.encrypt(
+          data: applicant_pii.to_json, key: encryption_key, iv: front_image_iv,
+        ))
+        stub_request(:get, back_image_url).to_return(body: encryption_helper.encrypt(
+          data: applicant_pii.to_json, key: encryption_key, iv: back_image_iv,
+        ))
+        stub_request(:get, selfie_image_url).to_return(body: encryption_helper.encrypt(
+          data: applicant_pii.to_json, key: encryption_key, iv: selfie_image_iv,
+        ))
       end
 
       it 'still downloads and decrypts the content' do

--- a/spec/lib/encryption_helper_spec.rb
+++ b/spec/lib/encryption_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe IdentityIdpFunctions::EncryptionHelper do
     let(:plaintext) { 'the quick brown fox jumps over the lazy dog' }
 
     it 'decrypts data' do
-      encrypted = encrypt(data: plaintext, iv: iv, key: key)
+      encrypted = encryption_helper.encrypt(data: plaintext, iv: iv, key: key)
 
       expect(encryption_helper.decrypt(data: encrypted, iv: iv, key: key)).to eq(plaintext)
     end

--- a/spec/support/encryption.rb
+++ b/spec/support/encryption.rb
@@ -2,7 +2,9 @@ def encrypt_and_stub_s3(body:, url:, iv:, key:)
   prefix = URI(url).path.gsub(%r{^/}, '')
 
   @responses ||= {}
-  @responses[prefix] = encrypt(data: body, iv: iv, key: key)
+  @responses[prefix] = IdentityIdpFunctions::EncryptionHelper.new.encrypt(
+    data: body, iv: iv, key: key,
+  )
 
   Aws.config[:s3] = {
     stub_responses: {
@@ -11,17 +13,4 @@ def encrypt_and_stub_s3(body:, url:, iv:, key:)
       end,
     },
   }
-end
-
-def encrypt(data:, iv:, key:)
-  cipher = OpenSSL::Cipher.new('aes-256-gcm')
-  cipher.encrypt
-  cipher.iv = iv
-  cipher.key = key
-  cipher.auth_data = ''
-
-  encrypted = cipher.update(data) + cipher.final
-  tag = cipher.auth_tag # produces 16 bytes tag by default
-
-  encrypted + tag
 end


### PR DESCRIPTION
As I'm cleaning up https://github.com/18F/identity-idp/pull/4464, I realized I wanted this method and didn't want to reimplement it