### PR TITLE
Move S3 dependency into individual functions

### DIFF
--- a/source/aws-ruby-sdk/s3_helper.rb
+++ b/source/aws-ruby-sdk/s3_helper.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk-s3'
-
 module IdentityIdpFunctions
   class S3Helper
     def s3_url?(url)
@@ -19,6 +17,8 @@ module IdentityIdpFunctions
     end
 
     def s3_client
+      require 'aws-sdk-s3'
+
       @s3_client ||= Aws::S3::Client.new(
         http_open_timeout: 5,
         http_read_timeout: 5,

--- a/source/proof_document/lib/Gemfile
+++ b/source/proof_document/lib/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '~> 2.7.0'
 
+gem 'aws-sdk-s3'
 gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.1'

--- a/source/proof_document_mock/lib/Gemfile
+++ b/source/proof_document_mock/lib/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '~> 2.7.0'
 
+gem 'aws-sdk-s3'
 gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.1'


### PR DESCRIPTION
- Also make gem require lazy, because we load the helpers
  in every single function, even the ones that don't need S3

Error in deployed env:

```
{
    "errorMessage": "cannot load such file -- aws-sdk-s3",
    "errorType": "Init<LoadError>",
    "stackTrace": [
        "/opt/ruby/lib/s3_helper.rb:1:in `require'",
        "/opt/ruby/lib/s3_helper.rb:1:in `<top (required)>'",
```

because the `ProofDocument` function didn't specify s3 as a dependency (even though `aws-sdk-ruby` did)

