### PR TITLE
Don't use param for alarm topic

### DIFF
--- a/source/template.yaml.erb
+++ b/source/template.yaml.erb
@@ -207,8 +207,9 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub
-          - '{{resolve:ssm:/account/${Region}/alert/sns/arn:1}}'
+          - arn:aws:sns:${Region}:${AccountId}:slack-otherevents
           - Region: !Ref AWS::Region
+            AccountId: !Ref AWS::AccountId
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions: 
         - Name: FunctionName


### PR DESCRIPTION
Since it is going to take some time to get the parameter and permissions deployed through all of the environments.  I set the parameter topic to a fixed SNS topic.  Will revisit once the parameter and permissions are deployed everywhere.