### PR TITLE
Empty version bump to generate a new SHA

### DIFF
--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end


### PR DESCRIPTION
This is my guess at fixing async... maybe the previous SHA on `main` just didn't make it through the pipeline (the build was flakey yesterday), so I want to see if just generating a new one will do the trick