### PR TITLE
All TCP port 443 traffic to vpc

### DIFF
--- a/source/template.yaml.erb
+++ b/source/template.yaml.erb
@@ -221,6 +221,10 @@ Resources:
           FromPort: 3128
           ToPort: 3128
           CidrIp: 172.16.32.0/22
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 172.16.32.0/22
 
   DocAuthLayer:
     Type: "AWS::Serverless::LayerVersion"


### PR DESCRIPTION
Update security group to allow traffic on port 443 to the vpc.

Tested ProofAddressMockFunction was able to reach IDP server.
```
START RequestId: 219c1ec1-633b-4be2-964d-9330e1524a7a Version: $LATEST
{"name":"ProofAddressMock","trace_id":null,"success":true,"timing":{"address":0.08,"callback":316.97},"time":"2021-02-02T21:08:27+00:00","level":"INFO"}
Error raised from handler method{
  "errorMessage": "the server responded with status 404",
  "errorType": "Function<Faraday::ResourceNotFound>",
  "stackTrace": [
    "/var/task/vendor/bundle/ruby/2.7.0/gems/faraday-1.3.0/lib/faraday/response/raise_error.rb:22:in `on_complete'",
    "/var/task/vendor/bundle/ruby/2.7.0/gems/faraday-1.3.0/lib/faraday/middleware.rb:19:in `block in call'",
    "/var/task/vendor/bundle/ruby/2.7.0/gems/faraday-1.3.0/lib/faraday/response.rb:59:in `on_complete'",
    "/var/task/vendor/bundle/ruby/2.7.0/gems/faraday-1.3.0/lib/faraday/middleware.rb:18:in `call'",
    "/var/task/vendor/bundle/ruby/2.7.0/gems/faraday-1.3.0/lib/faraday/rack_builder.rb:154:in `build_response'",
    "/var/task/vendor/bundle/ruby/2.7.0/gems/faraday-1.3.0/lib/faraday/connection.rb:492:in `run_request'",
    "/var/task/vendor/bundle/ruby/2.7.0/gems/faraday-1.3.0/lib/faraday/connection.rb:279:in `post'",
    "/var/task/proof_address_mock.rb:66:in `block in post_callback'",
    "/var/task/vendor/bundle/ruby/2.7.0/gems/retries-0.0.5/lib/retries.rb:46:in `with_retries'",
    "/var/task/proof_address_mock.rb:65:in `post_callback'",
    "/var/task/proof_address_mock.rb:52:in `block in proof'",
    "/opt/ruby/lib/timer.rb:14:in `time'",
    "/var/task/proof_address_mock.rb:51:in `proof'",
    "/var/task/proof_address_mock.rb:15:in `handle'"
  ]
}END RequestId: 219c1ec1-633b-4be2-964d-9330e1524a7a
REPORT RequestId: 219c1ec1-633b-4be2-964d-9330e1524a7a	Duration: 532.09 ms	Billed Duration: 533 ms	Memory Size: 128 MB	Max Memory Used: 110 MB	
XRAY TraceId: 1-6019bf4b-313d5df81c03b6933b776a1c	SegmentId: 611d6c425f545847	Sampled: true	

```
