### PR TITLE
Extract INVALID_STATE_ID_NUMBER constant to get fake AAMVA to fail

### DIFF
--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 end

--- a/source/proof_resolution_mock/lib/state_id_mock_client.rb
+++ b/source/proof_resolution_mock/lib/state_id_mock_client.rb
@@ -19,6 +19,8 @@ module IdentityIdpFunctions
       drivers_license drivers_permit state_id_card
     ].to_set.freeze
 
+    INVALID_STATE_ID_NUMBER = '00000000'.freeze
+
     proof do |applicant, result|
       if state_not_supported?(applicant[:state_id_jurisdiction])
         result.add_error(:state_id_jurisdiction, 'The jurisdiction could not be verified')

--- a/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
+++ b/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
@@ -170,10 +170,13 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
     end
 
     context 'with a failure response from the state id verifier' do
-      it 'is a failure response' do
-        expect(function.state_id_mock_proofer).to receive(:proof).
-          and_return(Proofer::Result.new(exception: 'some error'))
+      let(:applicant_pii) do
+        super().merge(
+          state_id_number: IdentityIdpFunctions::StateIdMockClient::INVALID_STATE_ID_NUMBER,
+        )
+      end
 
+      it 'is a failure response' do
         resolution_result = nil
         function.proof do |response|
           resolution_result = response[:resolution_result]


### PR DESCRIPTION
- Test already covered this case via mocking, this makes it "realer"
  and easier to reference in our code and documentation

The behavior/spec was already added in the previous fix PR https://github.com/18F/identity-idp-functions/pull/58/files#diff-37ba6efcb7f781bae3dc396618f0baaeb8646dcde8d3a872b126764580ba3ca0R172-R185