### PR TITLE
Include transaction_id from AAMVA (LG-4257)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'aamva', '>= 3.5.0', github: '18F/identity-aamva-api-client-gem', branch: 'margolis-transaction-id'
+gem 'aamva', github: '18F/identity-aamva-api-client-gem', branch: 'margolis-transaction-id'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.1'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.0'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.8.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
+gem 'aamva', '>= 3.5.0', github: '18F/identity-aamva-api-client-gem', branch: 'margolis-transaction-id'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.1'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.0'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.8.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'aamva', github: '18F/identity-aamva-api-client-gem', branch: 'margolis-transaction-id'
+gem 'aamva', github: '18F/identity-aamva-api-client-gem', branch: 'v3.5.0'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.1'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.0'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.8.0'

--- a/identity-idp-functions.gemspec
+++ b/identity-idp-functions.gemspec
@@ -28,5 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-ssm', '>= 1.55'
   spec.add_dependency 'retries', '>= 0.0.5'
 
+  # Git dependency
+  spec.add_dependency 'aamva', '>= 3.5.0'
+
   spec.add_development_dependency 'rake', '~> 13'
 end

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.10.1'
+  VERSION = '0.11.0'
 end

--- a/source/proof_resolution/lib/Gemfile
+++ b/source/proof_resolution/lib/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '~> 2.7.0'
 
-gem 'aamva', '>= 3.5.0', github: '18F/identity-aamva-api-client-gem', branch: 'margolis-transaction-id'
+gem 'aamva', github: '18F/identity-aamva-api-client-gem', branch: 'margolis-transaction-id'
 gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.0'

--- a/source/proof_resolution/lib/Gemfile
+++ b/source/proof_resolution/lib/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '~> 2.7.0'
 
-gem 'aamva', github: '18F/identity-aamva-api-client-gem', branch: 'margolis-transaction-id'
+gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.5.0'
 gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.0'

--- a/source/proof_resolution/lib/Gemfile
+++ b/source/proof_resolution/lib/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '~> 2.7.0'
 
-gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
+gem 'aamva', '>= 3.5.0', github: '18F/identity-aamva-api-client-gem', branch: 'margolis-transaction-id'
 gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.0'

--- a/source/proof_resolution/spec/proof_resolution_spec.rb
+++ b/source/proof_resolution/spec/proof_resolution_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
         'Status' => {
           'TransactionStatus' => 'passed',
           'ConversationId' => lexisnexis_transaction_id,
-         },
+        },
       }
     end
 
@@ -88,7 +88,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
                 state_id: Aamva::Proofer.vendor_name,
                 transaction_id: aamva_transaction_id,
               },
-            ]
+            ],
           },
           transaction_id: lexisnexis_transaction_id,
         },
@@ -141,7 +141,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
                   state_id: Aamva::Proofer.vendor_name,
                   transaction_id: aamva_transaction_id,
                 },
-              ]
+              ],
             },
             transaction_id: lexisnexis_transaction_id,
           },
@@ -193,7 +193,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
                   resolution: LexisNexis::InstantVerify::Proofer.vendor_name,
                   transaction_id: nil,
                 },
-              ]
+              ],
             },
             transaction_id: nil,
           },

--- a/source/proof_resolution_mock/lib/resolution_mock_client.rb
+++ b/source/proof_resolution_mock/lib/resolution_mock_client.rb
@@ -14,6 +14,7 @@ module IdentityIdpFunctions
 
     UNVERIFIABLE_ZIP_CODE = '00000'
     NO_CONTACT_SSN = '000-00-0000'
+    TRANSACTION_ID = 'resolution-mock-transaction-id-123'
 
     proof do |applicant, result|
       first_name = applicant[:first_name]
@@ -34,6 +35,8 @@ module IdentityIdpFunctions
       elsif applicant[:zipcode] == UNVERIFIABLE_ZIP_CODE
         result.add_error(:zipcode, 'Unverified ZIP code.')
       end
+
+      result.transaction_id = TRANSACTION_ID
     end
   end
 end

--- a/source/proof_resolution_mock/lib/state_id_mock_client.rb
+++ b/source/proof_resolution_mock/lib/state_id_mock_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'proofer'
 
 module IdentityIdpFunctions
@@ -19,7 +21,7 @@ module IdentityIdpFunctions
       drivers_license drivers_permit state_id_card
     ].to_set.freeze
 
-    INVALID_STATE_ID_NUMBER = '00000000'.freeze
+    INVALID_STATE_ID_NUMBER = '00000000'
 
     TRANSACTION_ID = 'state-id-mock-transaction-id-456'
 

--- a/source/proof_resolution_mock/lib/state_id_mock_client.rb
+++ b/source/proof_resolution_mock/lib/state_id_mock_client.rb
@@ -21,6 +21,8 @@ module IdentityIdpFunctions
 
     INVALID_STATE_ID_NUMBER = '00000000'.freeze
 
+    TRANSACTION_ID = 'state-id-mock-transaction-id-456'
+
     proof do |applicant, result|
       if state_not_supported?(applicant[:state_id_jurisdiction])
         result.add_error(:state_id_jurisdiction, 'The jurisdiction could not be verified')
@@ -31,6 +33,8 @@ module IdentityIdpFunctions
       elsif invalid_state_id_type?(applicant[:state_id_type])
         result.add_error(:state_id_type, 'The state ID type could not be verified')
       end
+
+      result.transaction_id = TRANSACTION_ID
     end
 
     private

--- a/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
+++ b/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
       state_id_jurisdiction: 'WI',
     }
   end
+  let(:resolution_transaction_id) { IdentityIdpFunctions::ResolutionMockClient::TRANSACTION_ID }
+  let(:state_id_transaction_id) { IdentityIdpFunctions::StateIdMockClient::TRANSACTION_ID }
 
   before do
     stub_const(
@@ -45,10 +47,13 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
             messages: [],
             success: true,
             timed_out: false,
-            context: { stages: [
-              { resolution: 'ResolutionMock' },
-              { state_id: 'StateIdMock' },
-            ] },
+            context: {
+              stages: [
+                { resolution: 'ResolutionMock', transaction_id: resolution_transaction_id },
+                { state_id: 'StateIdMock', transaction_id: state_id_transaction_id },
+              ],
+            },
+            transaction_id: resolution_transaction_id,
           },
         )
       end
@@ -84,10 +89,13 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
             messages: [],
             success: true,
             timed_out: false,
-            context: { stages: [
-              { resolution: 'ResolutionMock' },
-              { state_id: 'StateIdMock' },
-            ] },
+            context: {
+              stages: [
+                { resolution: 'ResolutionMock', transaction_id: resolution_transaction_id },
+                { state_id: 'StateIdMock', transaction_id: state_id_transaction_id },
+              ],
+            },
+            transaction_id: resolution_transaction_id,
           },
         )
 


### PR DESCRIPTION
- Updates to send transaction_id for lexisnexis, aamva separately
- Updates mock proofer to send transaction_id as well
