### PR TITLE
LG-4265: Include transaction ID in address result

### DIFF
--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'
 end

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -37,6 +37,7 @@ module IdentityIdpFunctions
 
       result = proofer_result.to_h
       result[:context] = { stages: [address: LexisNexis::PhoneFinder::Proofer.vendor_name] }
+      result[:transaction_id] = proofer_result.transaction_id
 
       result[:timed_out] = proofer_result.timed_out?
       result[:exception] = proofer_result.exception.inspect if proofer_result.exception

--- a/source/proof_address/spec/proof_address_spec.rb
+++ b/source/proof_address/spec/proof_address_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
   let(:idp_api_auth_token) { SecureRandom.hex }
   let(:callback_url) { 'https://example.login.gov/api/callbacks/proof-address/:token' }
   let(:trace_id) { SecureRandom.uuid }
+  let(:conversation_id) { SecureRandom.hex }
   let(:applicant_pii) do
     {
       first_name: 'Johnny',
@@ -35,7 +36,12 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
         :post,
         'https://lexisnexis.example.com/restws/identity/v2/abc123/aaa/conversation',
       ).to_return(
-        body: { 'Status' => { 'TransactionStatus' => 'passed' } }.to_json,
+        body: {
+          Status: {
+            ConversationId: conversation_id,
+            TransactionStatus: 'passed',
+          },
+        }.to_json,
       )
 
       stub_request(:post, callback_url).
@@ -52,6 +58,7 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
               messages: [],
               success: true,
               timed_out: false,
+              transaction_id: conversation_id,
               context: { stages: [
                 { address: 'lexisnexis:phone_finder' },
               ] },
@@ -89,6 +96,7 @@ RSpec.describe IdentityIdpFunctions::ProofAddress do
             messages: [],
             success: true,
             timed_out: false,
+            transaction_id: conversation_id,
             context: { stages: [
               { address: 'lexisnexis:phone_finder' },
             ] },

--- a/source/proof_address_mock/lib/address_mock_client.rb
+++ b/source/proof_address_mock/lib/address_mock_client.rb
@@ -15,6 +15,7 @@ module IdentityIdpFunctions
     UNVERIFIABLE_PHONE_NUMBER = '7035555555'
     PROOFER_TIMEOUT_PHONE_NUMBER = '7035555888'
     FAILED_TO_CONTACT_PHONE_NUMBER = '7035555999'
+    TRANSACTION_ID = 'address-mock-transaction-id-123'
 
     proof do |applicant, result|
       plain_phone = applicant[:phone].gsub(/\D/, '').gsub(/\A1/, '')
@@ -25,6 +26,7 @@ module IdentityIdpFunctions
       elsif plain_phone == PROOFER_TIMEOUT_PHONE_NUMBER
         raise Proofer::TimeoutError, 'address mock timeout'
       end
+      result.transaction_id = TRANSACTION_ID
       result.context[:message] = 'some context for the mock address proofer'
     end
   end

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -37,6 +37,7 @@ module IdentityIdpFunctions
       result[:context] = { stages: [
         address: IdentityIdpFunctions::AddressMockClient.vendor_name,
       ] }
+      result[:transaction_id] = proofer_result.transaction_id
 
       result[:timed_out] = proofer_result.timed_out?
       result[:exception] = proofer_result.exception.inspect if proofer_result.exception

--- a/source/proof_address_mock/spec/proof_address_mock_spec.rb
+++ b/source/proof_address_mock/spec/proof_address_mock_spec.rb
@@ -4,6 +4,7 @@ require 'identity-idp-functions/proof_address_mock'
 RSpec.describe IdentityIdpFunctions::ProofAddressMock do
   let(:idp_api_auth_token) { SecureRandom.hex }
   let(:callback_url) { 'https://example.login.gov/api/callbacks/proof-address/:token' }
+  let(:transaction_id) { IdentityIdpFunctions::AddressMockClient::TRANSACTION_ID }
   let(:applicant_pii) do
     {
       first_name: 'Johnny',
@@ -36,6 +37,7 @@ RSpec.describe IdentityIdpFunctions::ProofAddressMock do
             messages: [],
             success: true,
             timed_out: false,
+            transaction_id: transaction_id,
             context: { stages: [
               { address: 'AddressMock' },
             ] },
@@ -72,6 +74,7 @@ RSpec.describe IdentityIdpFunctions::ProofAddressMock do
             messages: [],
             success: true,
             timed_out: false,
+            transaction_id: transaction_id,
             context: { stages: [
               { address: 'AddressMock' },
             ] },


### PR DESCRIPTION
Similar to: #60

**Why**: So that downstream logging includes conversation ID from LexisNexis address proofing result.