### PR TITLE
Update AAMVA gem to use explicit configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'aamva', github: '18F/identity-aamva-api-client-gem', branch: 'v3.5.0'
+gem 'aamva', github: '18F/identity-aamva-api-client-gem', branch: 'v4.0.0'
 gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.4.1'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.0'
 gem 'proofer', github: '18F/identity-proofer-gem', tag: 'v2.8.0'

--- a/identity-idp-functions.gemspec
+++ b/identity-idp-functions.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'retries', '>= 0.0.5'
 
   # Git dependency
-  spec.add_dependency 'aamva', '>= 3.5.0'
+  spec.add_dependency 'aamva', '>= 4.0.0'
 
   spec.add_development_dependency 'rake', '~> 13'
 end

--- a/lib/identity-idp-functions/version.rb
+++ b/lib/identity-idp-functions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityIdpFunctions
-  VERSION = '0.13.0'
+  VERSION = '0.14.0'
 end

--- a/source/doc_auth_layer/errors.rb
+++ b/source/doc_auth_layer/errors.rb
@@ -1,9 +1,6 @@
 module IdentityIdpFunctions
   module Errors
     class MisconfiguredLambdaError < StandardError
-      def message
-        'IDP_API_AUTH_TOKEN is not configured'
-      end
     end
   end
 end

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -28,7 +28,7 @@ module IdentityIdpFunctions
       set_up_env!
 
       if !block_given? && api_auth_token.to_s.empty?
-        raise Errors::MisconfiguredLambdaError.new('IDP_API_AUTH_TOKEN is not configured')
+        raise Errors::MisconfiguredLambdaError, 'IDP_API_AUTH_TOKEN is not configured'
       end
 
       proofer_result = timer.time('address') do

--- a/source/proof_address/lib/proof_address.rb
+++ b/source/proof_address/lib/proof_address.rb
@@ -27,7 +27,9 @@ module IdentityIdpFunctions
     def proof
       set_up_env!
 
-      raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
+      if !block_given? && api_auth_token.to_s.empty?
+        raise Errors::MisconfiguredLambdaError.new('IDP_API_AUTH_TOKEN is not configured')
+      end
 
       proofer_result = timer.time('address') do
         with_retries(**faraday_retry_options) do

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -26,7 +26,7 @@ module IdentityIdpFunctions
 
     def proof
       if !block_given? && api_auth_token.to_s.empty?
-        raise Errors::MisconfiguredLambdaError.new('IDP_API_AUTH_TOKEN is not configured')
+        raise Errors::MisconfiguredLambdaError, 'IDP_API_AUTH_TOKEN is not configured'
       end
 
       proofer_result = timer.time('address') do

--- a/source/proof_address_mock/lib/proof_address_mock.rb
+++ b/source/proof_address_mock/lib/proof_address_mock.rb
@@ -25,7 +25,9 @@ module IdentityIdpFunctions
     end
 
     def proof
-      raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
+      if !block_given? && api_auth_token.to_s.empty?
+        raise Errors::MisconfiguredLambdaError.new('IDP_API_AUTH_TOKEN is not configured')
+      end
 
       proofer_result = timer.time('address') do
         with_retries(**faraday_retry_options) do

--- a/source/proof_resolution/lib/Gemfile
+++ b/source/proof_resolution/lib/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '~> 2.7.0'
 
-gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.5.0'
+gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v4.0.0'
 gem 'aws-sdk-ssm', '~> 1.55'
 gem 'faraday'
 gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.5.0'

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -16,18 +16,23 @@ module IdentityIdpFunctions
       new(**params).proof(&callback_block)
     end
 
-    attr_reader :applicant_pii,
+    attr_reader :aamva_config,
+                :applicant_pii,
                 :callback_url,
                 :trace_id,
                 :timer
 
+    # @param [Hash] aamva_config should only be included when run in-process, this config includes
+    # secrets that should should not be sent in the lambda payload
     def initialize(
+      aamva_config: {},
       applicant_pii:,
       callback_url:,
       should_proof_state_id:,
       dob_year_only: false,
       trace_id: nil
     )
+      @aamva_config = aamva_config
       @applicant_pii = applicant_pii
       @callback_url = callback_url
       @should_proof_state_id = should_proof_state_id
@@ -55,7 +60,17 @@ module IdentityIdpFunctions
     def proof
       set_up_env!
 
-      raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
+      if !block_given?
+        if api_auth_token.to_s.empty?
+          raise Errors::MisconfiguredLambdaError.new('IDP_API_AUTH_TOKEN is not configured')
+        end
+
+        if !aamva_config.empty?
+          raise Errors::MisconfiguredLambdaError.new(
+            'aamva config should not be present in lambda payload',
+          )
+        end
+      end
 
       callback_log_data = if dob_year_only? && should_proof_state_id?
                             proof_aamva_then_lexisnexis_dob_only
@@ -200,8 +215,6 @@ module IdentityIdpFunctions
         lexisnexis_password
         lexisnexis_base_url
         lexisnexis_instant_verify_workflow
-        aamva_public_key
-        aamva_private_key
       ].each do |env_key|
         ENV[env_key] ||= ssm_helper.load(env_key)
       end
@@ -224,7 +237,15 @@ module IdentityIdpFunctions
     end
 
     def aamva_proofer
-      Aamva::Proofer.new
+      @aamva_proofer ||= Aamva::Proofer.new(
+        auth_request_timeout: aamva_config[:auth_request_timeout],
+        auth_url: aamva_config[:auth_url],
+        cert_enabled: aamva_config[:cert_enabled],
+        private_key: aamva_config[:private_key] || ssm_helper.load('aamva_private_key'),
+        public_key: aamva_config[:public_key] || ssm_helper.load('aamva_public_key'),
+        verification_request_timeout: aamva_config[:verification_request_timeout],
+        verification_url: aamva_config[:verification_url],
+      )
     end
 
     def api_auth_token

--- a/source/proof_resolution/lib/proof_resolution.rb
+++ b/source/proof_resolution/lib/proof_resolution.rb
@@ -16,28 +16,28 @@ module IdentityIdpFunctions
       new(**params).proof(&callback_block)
     end
 
-    attr_reader :aamva_config,
-                :applicant_pii,
+    attr_reader :applicant_pii,
                 :callback_url,
                 :trace_id,
+                :aamva_config,
                 :timer
 
     # @param [Hash] aamva_config should only be included when run in-process, this config includes
     # secrets that should should not be sent in the lambda payload
     def initialize(
-      aamva_config: {},
       applicant_pii:,
       callback_url:,
       should_proof_state_id:,
       dob_year_only: false,
-      trace_id: nil
+      trace_id: nil,
+      aamva_config: {}
     )
-      @aamva_config = aamva_config
       @applicant_pii = applicant_pii
       @callback_url = callback_url
       @should_proof_state_id = should_proof_state_id
       @dob_year_only = dob_year_only
       @trace_id = trace_id
+      @aamva_config = aamva_config
       @timer = IdentityIdpFunctions::Timer.new
     end
 
@@ -62,13 +62,12 @@ module IdentityIdpFunctions
 
       if !block_given?
         if api_auth_token.to_s.empty?
-          raise Errors::MisconfiguredLambdaError.new('IDP_API_AUTH_TOKEN is not configured')
+          raise Errors::MisconfiguredLambdaError, 'IDP_API_AUTH_TOKEN is not configured'
         end
 
         if !aamva_config.empty?
-          raise Errors::MisconfiguredLambdaError.new(
-            'aamva config should not be present in lambda payload',
-          )
+          raise Errors::MisconfiguredLambdaError,
+                'aamva config should not be present in lambda payload'
         end
       end
 

--- a/source/proof_resolution/spec/proof_resolution_spec.rb
+++ b/source/proof_resolution/spec/proof_resolution_spec.rb
@@ -134,8 +134,8 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
         super().merge(
           aamva_config: {
             private_key: 'aaa',
-            public_key: 'bbb'
-          }
+            public_key: 'bbb',
+          },
         )
       end
 
@@ -191,16 +191,16 @@ RSpec.describe IdentityIdpFunctions::ProofResolution do
           super().merge(
             aamva_config: {
               private_key: 'overridden value',
-              public_key: 'overridden value'
-            }
+              public_key: 'overridden value',
+            },
           )
         end
 
         it 'passes aamva params to the aamva gem' do
           expect(Aamva::Proofer).to receive(:new).with(hash_including(
-            private_key: 'overridden value',
-            public_key: 'overridden value'
-          )).and_call_original
+                                                         private_key: 'overridden value',
+                                                         public_key: 'overridden value',
+                                                       )).and_call_original
 
           expect(yielded_result).to be
         end

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -42,7 +42,9 @@ module IdentityIdpFunctions
     end
 
     def proof
-      raise Errors::MisconfiguredLambdaError if !block_given? && api_auth_token.to_s.empty?
+      if !block_given? && api_auth_token.to_s.empty?
+        raise Errors::MisconfiguredLambdaError.new('IDP_API_AUTH_TOKEN is not configured')
+      end
 
       proofer_result = timer.time('resolution') do
         with_retries(**faraday_retry_options) do

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -43,7 +43,7 @@ module IdentityIdpFunctions
 
     def proof
       if !block_given? && api_auth_token.to_s.empty?
-        raise Errors::MisconfiguredLambdaError.new('IDP_API_AUTH_TOKEN is not configured')
+        raise Errors::MisconfiguredLambdaError, 'IDP_API_AUTH_TOKEN is not configured'
       end
 
       proofer_result = timer.time('resolution') do

--- a/source/proof_resolution_mock/lib/proof_resolution_mock.rb
+++ b/source/proof_resolution_mock/lib/proof_resolution_mock.rb
@@ -23,13 +23,15 @@ module IdentityIdpFunctions
       callback_url:,
       should_proof_state_id:,
       dob_year_only: false,
-      trace_id: nil
+      trace_id: nil,
+      aamva_config: {} # interface compatibility with ProofResolution
     )
       @applicant_pii = applicant_pii
       @callback_url = callback_url
       @should_proof_state_id = should_proof_state_id
       @dob_year_only = dob_year_only
       @trace_id = trace_id
+      @aamva_config = aamva_config
       @timer = IdentityIdpFunctions::Timer.new
     end
 

--- a/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
+++ b/source/proof_resolution_mock/spec/proof_resolution_mock_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe IdentityIdpFunctions::ProofResolutionMock do
         should_proof_state_id: true,
         applicant_pii: applicant_pii,
         trace_id: trace_id,
+        aamva_config: {}, # interface compatibiltiy with ProofResolution
       }
     end
 


### PR DESCRIPTION
- For local invocation, adds an :aamva_config to the job 

Will make a PR to update Lambda::Runner in the IDP as well to handle this