### PR TITLE
Add lambda function to deliver RISC notifications

### DIFF
--- a/lib/identity-idp-functions/risc_notification.rb
+++ b/lib/identity-idp-functions/risc_notification.rb
@@ -1,0 +1,4 @@
+require 'identity-idp-functions'
+
+# This is a trampoline to allow lazily loading the risc_notification function
+require IdentityIdpFunctions.function_path('risc_notification')

--- a/source/risc_notification/lib/Gemfile
+++ b/source/risc_notification/lib/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+ruby '~> 2.7.0'
+
+gem 'faraday'

--- a/source/risc_notification/lib/risc_notification.rb
+++ b/source/risc_notification/lib/risc_notification.rb
@@ -1,0 +1,39 @@
+require 'bundler/setup' if !defined?(Bundler)
+require '/opt/ruby/lib/function_helper' if !defined?(IdentityIdpFunctions::FunctionHelper)
+
+module IdentityIdpFunctions
+  class RiscNotification
+    include IdentityIdpFunctions::FaradayHelper
+    include IdentityIdpFunctions::LoggingHelper
+
+    def self.handle(event:, context:)
+      params = JSON.parse(event.to_json, symbolize_names: true)
+      new(**params).notify
+    end
+
+    attr_reader :push_notification_url, :jwt, :timer
+
+    def initialize(push_notification_url:, jwt:)
+      @push_notification_url = push_notification_url
+      @jwt = jwt
+      @timer = IdentityIdpFunctions::Timer.new
+    end
+
+    def notify
+      response = timer.time('deliver_notification') do
+        build_faraday.post(
+          push_notification_url,
+          jwt,
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/secevent+jwt',
+        )
+      end
+    ensure
+      log_event(
+        name: 'RiscNotification',
+        response_code: response&.status,
+        timing: timer.results,
+      )
+    end
+  end
+end

--- a/source/risc_notification/lib/risc_notification.rb
+++ b/source/risc_notification/lib/risc_notification.rb
@@ -6,7 +6,7 @@ module IdentityIdpFunctions
     include IdentityIdpFunctions::FaradayHelper
     include IdentityIdpFunctions::LoggingHelper
 
-    def self.handle(event:, context:)
+    def self.handle(event:, context:) # rubocop:disable Lint/UnusedMethodArgument
       params = JSON.parse(event.to_json, symbolize_names: true)
       new(**params).notify
     end

--- a/source/risc_notification/spec/risc_notification_spec.rb
+++ b/source/risc_notification/spec/risc_notification_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe IdentityIdpFunctions::RiscNotification do
 
     it 'posts to the push_notification_url with the right headers' do
       req = stub_request(:post, push_notification_url).with(
-              headers: {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/secevent+jwt',
-              },
-              body: jwt
-            )
+        headers: {
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/secevent+jwt',
+        },
+        body: jwt,
+      )
 
       IdentityIdpFunctions::RiscNotification.handle(event: event, context: nil)
 
@@ -39,12 +39,12 @@ RSpec.describe IdentityIdpFunctions::RiscNotification do
       stub_request(:post, push_notification_url).to_return(status: 201)
 
       expect(function).to receive(:log_event).with(hash_including(
-        name: 'RiscNotification',
-        response_code: 201,
-        timing: {
-          'deliver_notification' => kind_of(Float),
-        }
-      ))
+                                                     name: 'RiscNotification',
+                                                     response_code: 201,
+                                                     timing: {
+                                                       'deliver_notification' => kind_of(Float),
+                                                     },
+                                                   ))
 
       function.notify
     end
@@ -62,7 +62,7 @@ RSpec.describe IdentityIdpFunctions::RiscNotification do
 
       it 'still logs timing info' do
         expect(function).to receive(:log_event).with(
-          hash_including(name: 'RiscNotification')
+          hash_including(name: 'RiscNotification'),
         )
 
         expect { function.notify }.to raise_error(Faraday::ConnectionFailed)
@@ -82,7 +82,7 @@ RSpec.describe IdentityIdpFunctions::RiscNotification do
 
       it 'still logs timing info' do
         expect(function).to receive(:log_event).with(
-          hash_including(name: 'RiscNotification')
+          hash_including(name: 'RiscNotification'),
         )
 
         expect { function.notify }.to raise_error(Faraday::BadRequestError)
@@ -90,4 +90,3 @@ RSpec.describe IdentityIdpFunctions::RiscNotification do
     end
   end
 end
-

--- a/source/risc_notification/spec/risc_notification_spec.rb
+++ b/source/risc_notification/spec/risc_notification_spec.rb
@@ -1,0 +1,93 @@
+require 'identity-idp-functions/risc_notification'
+
+RSpec.describe IdentityIdpFunctions::RiscNotification do
+  let(:push_notification_url) { 'https://example.com/risc/notify' }
+  let(:jwt) { SecureRandom.hex } # opaque payload stands in for a real JWT
+
+  describe '.handle' do
+    let(:event) do
+      {
+        push_notification_url: push_notification_url,
+        jwt: jwt,
+      }
+    end
+
+    it 'posts to the push_notification_url with the right headers' do
+      req = stub_request(:post, push_notification_url).with(
+              headers: {
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/secevent+jwt',
+              },
+              body: jwt
+            )
+
+      IdentityIdpFunctions::RiscNotification.handle(event: event, context: nil)
+
+      expect(req).to have_been_requested
+    end
+  end
+
+  describe '#notify' do
+    subject(:function) do
+      IdentityIdpFunctions::RiscNotification.new(
+        push_notification_url: push_notification_url,
+        jwt: jwt,
+      )
+    end
+
+    it 'logs timing info and the response code' do
+      stub_request(:post, push_notification_url).to_return(status: 201)
+
+      expect(function).to receive(:log_event).with(hash_including(
+        name: 'RiscNotification',
+        response_code: 201,
+        timing: {
+          'deliver_notification' => kind_of(Float),
+        }
+      ))
+
+      function.notify
+    end
+
+    context 'with a timeout from the endpoint' do
+      before do
+        stub_request(:post, push_notification_url).to_timeout
+      end
+
+      it 'raises and does not retry' do
+        expect { function.notify }.to raise_error(Faraday::ConnectionFailed)
+
+        expect(a_request(:post, push_notification_url)).to have_been_requested.once
+      end
+
+      it 'still logs timing info' do
+        expect(function).to receive(:log_event).with(
+          hash_including(name: 'RiscNotification')
+        )
+
+        expect { function.notify }.to raise_error(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'with a 400 from the endpoint' do
+      before do
+        stub_request(:post, push_notification_url).to_return(status: 400)
+      end
+
+      it 'raises and does not retry' do
+        expect { function.notify }.to raise_error(Faraday::BadRequestError)
+
+        expect(a_request(:post, push_notification_url)).to have_been_requested.once
+      end
+
+      it 'still logs timing info' do
+        expect(function).to receive(:log_event).with(
+          hash_including(name: 'RiscNotification')
+        )
+
+        expect { function.notify }.to raise_error(Faraday::BadRequestError)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
The goal for this function is that it's hooked up so that the `$ENV-risc-notification` SQS queue sends messages here

Looking for feedback on:
- **payload shape**: I made the payload just the URL and the JWT payload. My thinking was maybe at some point in the future we'd want a generic webhook lambda? So we would not want to hardcode some of the headers that we do? But we don't have a concrete need for that yet so I am opting to just leave this as is.
- **retry behavior**: For this first cut, I decided to just let the lambda raise on an unsuccessful POST (timeout, 4XX or 5XX) and not retry, that way we could easily let the SQS queue handle retrying?
